### PR TITLE
Fix non-sanitization of library soname in regex

### DIFF
--- a/packages/e4s_cl/cf/libraries/libraryset.py
+++ b/packages/e4s_cl/cf/libraries/libraryset.py
@@ -307,7 +307,8 @@ class LibrarySet(set):
         -> Library or None
         Returns the matching library if found in self, else None
         """
-        matches = set(filter(lambda x: re.match(soname, x.soname), self))
+        query = re.escape(soname)
+        matches = set(filter(lambda x: re.match(query, x.soname), self))
 
         return matches.pop() if matches else None
 

--- a/packages/e4s_cl/cf/tests/test_libraries.py
+++ b/packages/e4s_cl/cf/tests/test_libraries.py
@@ -113,3 +113,8 @@ class LibraryTest(tests.TestCase):
         libset = LibrarySet.create_from([resolve('libm.so.6')])
 
         self.assertTrue(libset.complete)
+
+    def test_escape_soname(self):
+        libset = LibrarySet.create_from(['libm.so.6'])
+
+        self.assertFalse(libset.find('libc++'))


### PR DESCRIPTION
Fix #22 with a soname escape when used for search in a `libraryset` object.