### PR TITLE
Enable command passing on the init command line

### DIFF
--- a/e4s_cl/cli/arguments.py
+++ b/e4s_cl/cli/arguments.py
@@ -23,6 +23,9 @@ Action = argparse.Action
 ArgumentError = argparse.ArgumentError
 """Argument error exception base class."""
 
+ArgumentTypeError = argparse.ArgumentTypeError
+"""Argument type error exception."""
+
 ArgumentsNamespace = argparse.Namespace
 """Generic container for parsed arguments."""
 
@@ -629,6 +632,17 @@ def existing_posix_path_list(string):
     """Argument type callback.
     Asserts that the string corresponds to a list of existing paths."""
     return list(map(existing_posix_path, string.split(',')))
+
+
+def binary_in_path(string):
+    """ Argument type callback. Asserts the given string identifies a launcher binary
+    on the system. """
+
+    path = util.which(string)
+    if not path:
+        raise ArgumentTypeError(
+            f"Launcher argument '{string}' could not be resolved to a binary")
+    return path
 
 
 def _search_available_databases(model, field, regex):

--- a/e4s_cl/logger.py
+++ b/e4s_cl/logger.py
@@ -220,7 +220,7 @@ class LogFormatter(logging.Formatter):
 
     @on_stdout
     def INFO(self, record):
-        return self._format_message(record)
+        return self._format_message(record, header='[+] ')
 
     @on_stderr
     def DEBUG(self, record):


### PR DESCRIPTION
Instead of compiling a binary and deducing the launcher, propose a profile-detect like command line for the user to use whatever command they fancy, and base the profile initialization on it.