### PR TITLE
Wi4MPI Interface Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # E4S Container Launcher
 
-E4S container launcher is a tool to simplify running MPI applications in E4S containers with host libraries. This project is built upon the [MPICH ABI Compatibility Initiative](https://www.mpich.org/abi/).
+E4S container launcher is a tool to simplify running MPI applications in E4S containers with host libraries. This project is built upon the [MPICH ABI Compatibility Initiative](https://www.mpich.org/abi/) and CEA's [Wi4MPI](https://github.com/cea-hpc/wi4mpi).
 
 __Check out the documentation [here](https://e4s-cl.readthedocs.io/en/latest/index.html) !__
 

--- a/e4s_cl/__init__.py
+++ b/e4s_cl/__init__.py
@@ -95,6 +95,12 @@ CONTAINER_BINARY_DIR = Path(CONTAINER_DIR, "executables").as_posix()
 PROFILE_LIST_DEFAULT_COLUMNS = ["selected", "name", "backend", "image"]
 """list[str] columns to display in profile list by default"""
 
+WI4MPI_DIR = Path(USER_PREFIX) / "wi4mpi"
+"""Directory in which Wi4MPI releases and build will be put if needed"""
+
+WI4MPI_DEFAULT_INSTALL_DIR = WI4MPI_DIR / 'install'
+"""Default installation directory for Wi4MPI"""
+
 
 def version_banner():
     """Return a human readable text banner describing the E4S Container Launcher installation."""

--- a/e4s_cl/cf/detect_mpi.py
+++ b/e4s_cl/cf/detect_mpi.py
@@ -227,13 +227,16 @@ def filter_mpi_libs(libraries: List[Path]) -> Set[Path]:
     return set(filter(_filter_mpi, libraries))
 
 
-def install_dir(libraries: Iterable[Path]) -> Optional[Path]:
+def library_install_dir(libraries: Iterable[Path]) -> Optional[Path]:
     """
     Return the installation directory of a given list of libraries, defined as
     the common path stub containing the 'lib' folder
     """
 
     def _stub(library: Path) -> Optional[Path]:
+        """
+        Split a path at the 'lib' directory and return the part before
+        """
         path_elements = library.parts
         try:
             lib_index = path_elements.index('lib')

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -43,7 +43,7 @@ class MPIFamily:
 # MPI vendor libraries metadata. On top of the different MPI families, some
 # vendors adopt standard paths different from the norm. This collection keeps
 # track of all metadata for each of those vendors.
-WI4MPI_METADATA = {
+WI4MPI_METADATA = [
     MPIFamily(
         vendor_name='Intel(R) MPI',
         cli_name='intelmpi',
@@ -80,7 +80,7 @@ WI4MPI_METADATA = {
         mpi_c_soname='libmpi_cray.so',
         mpi_f_soname='libmpifort_cray.so',
     ),
-}
+]
 
 # Keys used to describe MPI families. Wi4MPI is needed if a pair of those keys
 # is present in the SUPPORTED_TRANSLATIONS collection

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -98,6 +98,19 @@ SUPPORTED_TRANSLATIONS = {
     ('openmpi', 'openmpi'),
 }
 
+_FAMILY_ENV_VARS = set(map(lambda x: x.path_key, WI4MPI_METADATA))
+
+# Set of all environment variables used by Wi4MPI, to pass to the underlying code
+WI4MPI_ENVIRONMENT_VARIABLES = {
+    'WI4MPI_ROOT',
+    'WI4MPI_FROM',
+    'WI4MPI_TO',
+    'WI4MPI_RUN_MPI_C_LIB',
+    'WI4MPI_RUN_MPI_F_LIB',
+    'WI4MPI_RUN_MPIIO_C_LIB',
+    'WI4MPI_RUN_MPIIO_F_LIB',
+} | _FAMILY_ENV_VARS
+
 
 def wi4mpi_identify(value: str) -> Optional[MPIFamily]:
     for family in WI4MPI_METADATA:

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -4,11 +4,11 @@ Module housing support for WI4MPI compatibility
 
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 from pathlib import Path
 from functools import lru_cache
 from e4s_cl import logger
-from e4s_cl.cf.detect_mpi import MPIIdentifier
+from e4s_cl.cf.detect_mpi import MPIIdentifier, library_install_dir
 from e4s_cl.cf.containers import Container
 from e4s_cl.cf.launchers import filter_arguments, Parser
 from e4s_cl.cf.launchers.mpirun import _wi4mpi_options
@@ -17,21 +17,34 @@ LOGGER = logger.get_logger(__name__)
 
 
 @dataclass(frozen=True)
-class _MPIFamily:
+class MPIFamily:
+    """
+    Dataclass to have compact objects with MPI vendor metadata
+    """
+    # Vendor name, as returned in MPIIdentifier
     vendor_name: str
+    # Name used by wi4mpi on the command line
     cli_name: str
+    # Name used by wi4mpi in the environment
     env_name: str
+    # Wi4MPI's environment variable for this family
     path_key: str
+    # Wi4MPI's default environment variable for this family
     default_path_key: str
+    # Default soname for this vendor's C library
     mpi_c_soname: str
+    # Default soname for this vendor Fortran library
     mpi_f_soname: str
 
     def __str__(self):
         return self.cli_name
 
 
+# MPI vendor libraries metadata. On top of the different MPI families, some
+# vendors adopt standard paths different from the norm. This collection keeps
+# track of all metadata for each of those vendors.
 WI4MPI_METADATA = {
-    _MPIFamily(**dict(
+    MPIFamily(
         vendor_name='Intel(R) MPI',
         cli_name='intelmpi',
         env_name='INTEL',
@@ -39,8 +52,8 @@ WI4MPI_METADATA = {
         default_path_key='INTELMPI_DEFAULT_ROOT',
         mpi_c_soname='libmpi.so',
         mpi_f_soname='libmpifort.so',
-    )),
-    _MPIFamily(**dict(
+    ),
+    MPIFamily(
         vendor_name='Open MPI',
         cli_name='openmpi',
         env_name='OMPI',
@@ -48,8 +61,8 @@ WI4MPI_METADATA = {
         default_path_key='OPENMPI_DEFAULT_ROOT',
         mpi_c_soname='libmpi.so',
         mpi_f_soname='libmpi_mpifh.so',
-    )),
-    _MPIFamily(**dict(
+    ),
+    MPIFamily(
         vendor_name='MPICH',
         cli_name='mpich',
         env_name='MPICH',
@@ -57,8 +70,8 @@ WI4MPI_METADATA = {
         default_path_key='MPICH_DEFAULT_ROOT',
         mpi_c_soname='libmpi.so',
         mpi_f_soname='libmpifort.so',
-    )),
-    _MPIFamily(**dict(
+    ),
+    MPIFamily(
         vendor_name='CRAY MPICH',
         cli_name='mpich',
         env_name='MPICH',
@@ -66,19 +79,27 @@ WI4MPI_METADATA = {
         default_path_key='MPICH_DEFAULT_ROOT',
         mpi_c_soname='libmpi_cray.so',
         mpi_f_soname='libmpifort_cray.so',
-    )),
+    ),
 }
+
+# Keys used to describe MPI families. Wi4MPI is needed if a pair of those keys
+# is present in the SUPPORTED_TRANSLATIONS collection
+WI4MPI_SOURCES = set(map(lambda x: x.cli_name,
+                         WI4MPI_METADATA)) | {'interface'}
 
 SUPPORTED_TRANSLATIONS = {
-    ('openmpi', 'intelpmi'),
     ('intelmpi', 'openmpi'),
-    ('openmpi', 'openmpi'),
-    ('openmpi', 'mpich'),
+    ('interface', 'intelpmi'),
+    ('interface', 'mpich'),
+    ('interface', 'openmpi'),
     ('mpich', 'openmpi'),
+    ('openmpi', 'intelpmi'),
+    ('openmpi', 'mpich'),
+    ('openmpi', 'openmpi'),
 }
 
 
-def wi4mpi_identify(value: str) -> Optional[_MPIFamily]:
+def wi4mpi_identify(value: str) -> Optional[MPIFamily]:
     for family in WI4MPI_METADATA:
         if value.lower() in {
                 family.vendor_name.lower(),
@@ -94,6 +115,15 @@ def wi4mpi_qualifier(value: MPIIdentifier) -> Optional[str]:
     match = wi4mpi_identify(value.vendor)
     if match:
         return match.cli_name
+    return None
+
+
+def wi4mpi_get_metadata(value: MPIIdentifier) -> Optional[MPIFamily]:
+    if not isinstance(value, MPIIdentifier):
+        return None
+    match = wi4mpi_identify(value.vendor)
+    if match:
+        return match
     return None
 
 
@@ -242,3 +272,70 @@ def wi4mpi_adapt_arguments(cmd_line: List[str]) -> List[str]:
         extra = ['-E', " ".join(mpi)]
 
     return list(filter(None, [launcher, *wi4mpi, *extra]))
+
+
+def wi4mpi_find_libraries(
+        target: MPIFamily,
+        mpi_libraries: List[Path]) -> Tuple[Optional[Path], Optional[Path]]:
+    """
+    Find the target's required MPI libraries from the paths in mpi_libraries
+    """
+
+    def locate(soname: str, available: List[Path]) -> Optional[Path]:
+        """
+        Find the library with the given soname, either from the libraries
+        passed in the list or from the directories they are in
+        """
+        matches = set(filter(lambda x: x.name.startswith(soname), available))
+        search_directories = set(map(lambda x: x.resolve().parent, available))
+
+        # If a match exists in the given libraries
+        if matches:
+            return matches.pop()
+
+        # Search the libraries' directories for the soname
+        for directory in search_directories:
+            matches = set(directory.glob(f"{soname}*"))
+            if matches:
+                return matches.pop()
+
+        LOGGER.debug(
+            "Failed to locate %(soname)s in %(directories)s",
+            {
+                "soname": soname,
+                "directories": search_directories,
+            },
+        )
+
+        return None
+
+    # Find the entry C and Fortran MPI libraries
+    run_c_lib = locate(target.mpi_c_soname, mpi_libraries)
+    run_f_lib = locate(target.mpi_f_soname, mpi_libraries)
+
+    return (run_c_lib, run_f_lib)
+
+
+def wi4mpi_prepare_environment_preload(
+    wi4mpi_install_dir: Path,
+    from_: str,
+    target: MPIFamily,
+    target_install_dir: Path,
+    run_c_lib: Path,
+    run_f_lib: Path,
+):
+
+    env = {
+        'WI4MPI_ROOT': str(wi4mpi_install_dir),
+        target.path_key: str(target_install_dir),
+        'WI4MPI_FROM': str(from_),
+        'WI4MPI_TO': str(target.cli_name),
+        'WI4MPI_RUN_MPI_C_LIB': str(run_c_lib),
+        'WI4MPI_RUN_MPI_F_LIB': str(run_f_lib),
+        'WI4MPI_RUN_MPIIO_C_LIB': str(run_c_lib),
+        'WI4MPI_RUN_MPIIO_F_LIB': str(run_f_lib),
+    }
+
+    LOGGER.debug("Wi4MPI environment: %s", env)
+    for key, value in env.items():
+        os.environ[key] = value

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -324,6 +324,18 @@ def wi4mpi_prepare_environment_preload(
     run_c_lib: Path,
     run_f_lib: Path,
 ):
+    """
+    Prepare the environment for a Wi4MPI execution in preload mode
+    Updates the environment variables:
+      + WI4MPI_ROOT
+      + WI4MPI_FROM
+      + WI4MPI_TO
+      + <LIBRARY>_ROOT
+      + WI4MPI_RUN_MPI_C_LIB
+      + WI4MPI_RUN_MPI_F_LIB
+      + WI4MPI_RUN_MPIIO_C_LIB
+      + WI4MPI_RUN_MPIIO_F_LIB
+    """
 
     env = {
         'WI4MPI_ROOT': str(wi4mpi_install_dir),
@@ -336,6 +348,40 @@ def wi4mpi_prepare_environment_preload(
         'WI4MPI_RUN_MPIIO_F_LIB': str(run_f_lib),
     }
 
-    LOGGER.debug("Wi4MPI environment: %s", env)
     for key, value in env.items():
+        LOGGER.debug("Wi4MPI preload: %s=%s", key, value)
+        os.environ[key] = value
+
+
+def wi4mpi_prepare_environment_interface(
+    wi4mpi_install_dir: Path,
+    target: MPIFamily,
+    target_install_dir: Path,
+    run_c_lib: Path,
+    run_f_lib: Path,
+):
+    """
+    Prepare the environment for a Wi4MPI execution in interface mode
+    Updates the environment variables:
+      + WI4MPI_ROOT
+      + WI4MPI_TO
+      + <LIBRARY>_ROOT
+      + WI4MPI_RUN_MPI_C_LIB
+      + WI4MPI_RUN_MPI_F_LIB
+      + WI4MPI_RUN_MPIIO_C_LIB
+      + WI4MPI_RUN_MPIIO_F_LIB
+    """
+
+    env = {
+        'WI4MPI_ROOT': str(wi4mpi_install_dir),
+        target.path_key: str(target_install_dir),
+        'WI4MPI_TO': str(target.cli_name),
+        'WI4MPI_RUN_MPI_C_LIB': str(run_c_lib),
+        'WI4MPI_RUN_MPI_F_LIB': str(run_f_lib),
+        'WI4MPI_RUN_MPIIO_C_LIB': str(run_c_lib),
+        'WI4MPI_RUN_MPIIO_F_LIB': str(run_f_lib),
+    }
+
+    for key, value in env.items():
+        LOGGER.debug("Wi4MPI interface: %s=%s", key, value)
         os.environ[key] = value

--- a/e4s_cl/cf/wi4mpi/install.py
+++ b/e4s_cl/cf/wi4mpi/install.py
@@ -8,7 +8,10 @@ import tarfile
 import urllib.request
 from pathlib import Path
 from typing import Optional
-from e4s_cl import USER_PREFIX
+from e4s_cl import (
+    USER_PREFIX,
+    WI4MPI_DIR,
+)
 from e4s_cl.util import (
     hash256,
     run_subprocess,
@@ -29,9 +32,6 @@ LOGGER = get_logger(__name__)
 WI4MPI_VERSION = Version('3.6.4')
 WI4MPI_RELEASE_URL = f"https://github.com/cea-hpc/wi4mpi/archive/refs/tags/v{WI4MPI_VERSION}.tar.gz"
 WI4MPI_RELEASE_SHA256 = "be1732a1aed1e2946873951a344b572f11f2a55cd06c634580a9398b5877e22a"
-WI4MPI_DIR = Path(USER_PREFIX) / "wi4mpi"
-DEFAULT_INSTALL_DIR = WI4MPI_DIR / 'install'
-
 CPU_COUNT = os.cpu_count()
 
 _WI4MPI_COMPILER_STRINGS = {
@@ -157,11 +157,8 @@ def _double_tap(cmd):
     return not success
 
 
-def install_wi4mpi(install_dir: Path = DEFAULT_INSTALL_DIR) -> Optional[Path]:
-    """Clones and installs wi4mpi from github releases
-    
-    Installs in ~/.local/share/wi4mpi using a GNU compiler
-    """
+def install_wi4mpi(install_dir: Path) -> Optional[Path]:
+    """Clones and installs wi4mpi from github releases"""
 
     if os.uname().machine not in {'x86_64', 'amd64'}:
         LOGGER.warning(

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -10,7 +10,12 @@ from typing import Union, List
 from pathlib import Path
 from sotools.linker import resolve
 from sotools.libraryset import LibrarySet, Library
-from e4s_cl import (EXIT_SUCCESS, E4S_CL_SCRIPT, logger, variables)
+from e4s_cl import (
+    E4S_CL_SCRIPT,
+    EXIT_SUCCESS,
+    logger,
+    variables,
+)
 from e4s_cl.util import which
 from e4s_cl.error import InternalError
 from e4s_cl.cli import arguments
@@ -18,8 +23,13 @@ from e4s_cl.cli.command import AbstractCommand
 from e4s_cl.cf.template import Entrypoint
 from e4s_cl.cf.containers import Container, FileOptions
 from e4s_cl.cf.libraries import (libc_version, library_links)
-from e4s_cl.cf.wi4mpi import (wi4mpi_root, wi4mpi_import, wi4mpi_libraries,
-                              wi4mpi_libpath, wi4mpi_preload)
+from e4s_cl.cf.wi4mpi import (
+    wi4mpi_import,
+    wi4mpi_libpath,
+    wi4mpi_libraries,
+    wi4mpi_preload,
+    wi4mpi_root,
+)
 
 LOGGER = logger.get_logger(__name__)
 _SCRIPT_CMD = Path(E4S_CL_SCRIPT).name
@@ -83,10 +93,19 @@ def overlay_libraries(library_set, container, entrypoint):
 
     # Hardcoded glib libraries sonames
     glib_sonames = [
-        'libcrypt.so.1', 'libc.so.6', 'libm.so.6', 'libmvec.so.1',
-        'libnsl.so.1', 'libnss_compat.so.2', 'libnss_db.so.2',
-        'libnss_dns.so.2', 'libnss_files.so.2', 'libnss_hesiod.so.2',
-        'libpthread.so.0', 'libresolv.so.2', 'librt.so.1'
+        'libc.so.6',
+        'libcrypt.so.1',
+        'libm.so.6',
+        'libmvec.so.1',
+        'libnsl.so.1',
+        'libnss_compat.so.2',
+        'libnss_db.so.2',
+        'libnss_dns.so.2',
+        'libnss_files.so.2',
+        'libnss_hesiod.so.2',
+        'libpthread.so.0',
+        'libresolv.so.2',
+        'librt.so.1',
     ]
     # Find the available libraries on the host, and bundle them in a set
     paths = filter(None, map(resolve, glib_sonames))
@@ -241,11 +260,6 @@ class ExecuteCommand(AbstractCommand):
                             help="Script to source",
                             metavar='libraries')
 
-        parser.add_argument('--wi4mpi',
-                            type=arguments.existing_posix_path,
-                            help="Directory of the Wi4MPI installation to use",
-                            metavar='wi4mpi_root')
-
         parser.add_argument('cmd',
                             type=str,
                             help="Executable command, e.g. './a.out'",
@@ -266,8 +280,10 @@ class ExecuteCommand(AbstractCommand):
         # script, that is then bound to the container to be executed
         params = Entrypoint()
 
-        # Assert the use of Wi4MPI
-        wi4mpi_install_dir = getattr(args, 'wi4mpi', None) or wi4mpi_root()
+        # Check the environment for the use of Wi4MPI
+        wi4mpi_install_dir = wi4mpi_root()
+
+        # List the required libraries for proper Wi4MPI execution
         wi4mpi_required = []
         if wi4mpi_install_dir is not None:
             wi4mpi_required = wi4mpi_libraries(wi4mpi_install_dir)

--- a/e4s_cl/cli/commands/init.py
+++ b/e4s_cl/cli/commands/init.py
@@ -77,8 +77,11 @@ from e4s_cl import (EXIT_FAILURE, EXIT_SUCCESS, E4S_CL_SCRIPT,
                     INIT_TEMP_PROFILE_NAME)
 from e4s_cl import logger, util
 from e4s_cl.cf.assets import precompiled_binaries, builtin_profiles
-from e4s_cl.cf.detect_mpi import (profile_mpi_name, filter_mpi_libs,
-                                  install_dir)
+from e4s_cl.cf.detect_mpi import (
+    filter_mpi_libs,
+    library_install_dir,
+    profile_mpi_name,
+)
 from e4s_cl.cf.containers import guess_backend, EXPOSED_BACKENDS
 from e4s_cl.cli.arguments import (binary_in_path, posix_path, get_parser,
                                   SUPPRESS, REMAINDER)
@@ -461,7 +464,7 @@ class InitCommand(AbstractCommand):
         # Check for MPI in the analysis' results
         profile_libraries = map(Path, selected_profile.get('libraries', []))
         profile_mpi_libraries = filter_mpi_libs(profile_libraries)
-        mpi_install_dir = install_dir(profile_mpi_libraries)
+        mpi_install_dir = library_install_dir(profile_mpi_libraries)
 
         # Simplify the profile by removing files contained in the MPI
         # installation directory

--- a/e4s_cl/cli/commands/launch.py
+++ b/e4s_cl/cli/commands/launch.py
@@ -37,11 +37,23 @@ from e4s_cl.cli.command import AbstractCommand
 from e4s_cl.cf.launchers import interpret, get_reserved_directories
 from e4s_cl.model.profile import Profile
 from e4s_cl.cf.containers import EXPOSED_BACKENDS
-from e4s_cl.cf.detect_mpi import (detect_mpi, install_dir, filter_mpi_libs)
-from e4s_cl.cf.wi4mpi import (wi4mpi_adapt_arguments, SUPPORTED_TRANSLATIONS,
-                              wi4mpi_qualifier, wi4mpi_identify,
-                              WI4MPI_METADATA, _MPIFamily)
-from e4s_cl.cf.wi4mpi.install import (WI4MPI_DIR, install_wi4mpi)
+from e4s_cl.cf.detect_mpi import (
+    detect_mpi,
+    filter_mpi_libs,
+    library_install_dir,
+)
+from e4s_cl.cf.wi4mpi import (
+    MPIFamily,
+    SUPPORTED_TRANSLATIONS,
+    WI4MPI_METADATA,
+    WI4MPI_SOURCES,
+    wi4mpi_find_libraries,
+    wi4mpi_get_metadata,
+    wi4mpi_identify,
+    wi4mpi_prepare_environment_preload,
+    wi4mpi_qualifier,
+)
+from e4s_cl.cf.wi4mpi.install import install_wi4mpi
 
 from e4s_cl.cli.commands.__execute import COMMAND as EXECUTE_COMMAND
 
@@ -108,9 +120,9 @@ def _format_execute(parameters: Parameters) -> List[str]:
 def _setup_wi4mpi(
     parameters: Parameters,
     translation: Tuple,
-    family_metadata: _MPIFamily,
+    family_metadata: MPIFamily,
     mpi_libraries: List[Path],
-) -> Tuple[List[str], List[str]]:
+) -> List[str]:
     """Prepare the environment for the use of Wi4MPI
     - Set or update 'wi4mpi' in the parameters
     - Update the environment variables:
@@ -125,7 +137,7 @@ def _setup_wi4mpi(
     - Prepare the wi4mpi launcher for the final command
     """
 
-    # Locate the Wi4MPI installation - either provided on the cli or default
+    # Locate the Wi4MPI installation and store it in parameters
     if parameters.wi4mpi is None:
         wi4mpi_install = install_wi4mpi()
         if wi4mpi_install:
@@ -136,64 +148,34 @@ def _setup_wi4mpi(
             )
             return []
 
-    def locate(soname: str, available: List[Path]) -> Optional[Path]:
-        matches = set(filter(lambda x: x.name.startswith(soname), available))
-        search_directories = set(map(lambda x: x.resolve().parent, available))
+    run_c_lib, run_f_lib = wi4mpi_find_libraries(family_metadata,
+                                                 mpi_libraries)
 
-        # If a match exists in the given libraries
-        if matches:
-            return matches.pop()
-
-        # Search the libraries' directories for the soname
-        for directory in search_directories:
-            matches = set(directory.glob(f"{soname}*"))
-            if matches:
-                return matches.pop()
-
-        LOGGER.debug(
-            "Failed to locate %(soname)s in %(directories)s",
-            dict(
-                soname=soname,
-                directories=search_directories,
-            ),
-        )
-
-        return None
-
-    # Find the entry C and Fortran MPI libraries
-    run_c_lib = locate(family_metadata.mpi_c_soname, mpi_libraries)
-    run_f_lib = locate(family_metadata.mpi_f_soname, mpi_libraries)
     if not (run_c_lib and run_f_lib):
         LOGGER.error(
             "Could not determine MPI libraries to use; Wi4MPI use aborted "
             "(no %(c_soname)s or %(f_soname)s in %(list)s)",
-            dict(
-                c_soname=family_metadata.mpi_c_soname,
-                f_soname=family_metadata.mpi_f_soname,
-                list=list(mpi_libraries),
-            ),
+            {
+                "c_soname": family_metadata.mpi_c_soname,
+                "f_soname": family_metadata.mpi_f_soname,
+                "list": list(mpi_libraries),
+            },
         )
         return []
 
-    # Deduce the MPI installation directory
-    mpi_install = install_dir([run_c_lib, run_f_lib])
+    # Deduce the MPI installation directory, add it to the imported files
+    mpi_install_dir = library_install_dir([run_c_lib, run_f_lib])
+    if mpi_install_dir:
+        parameters.files.add(mpi_install_dir)
 
-    parameters.files.add(mpi_install)
-
-    env = {
-        'WI4MPI_ROOT': str(parameters.wi4mpi),
-        'WI4MPI_FROM': str(translation[0]),
-        'WI4MPI_TO': str(translation[1]),
-        family_metadata.path_key: str(mpi_install),
-        'WI4MPI_RUN_MPI_C_LIB': str(run_c_lib),
-        'WI4MPI_RUN_MPI_F_LIB': str(run_f_lib),
-        'WI4MPI_RUN_MPIIO_C_LIB': str(run_c_lib),
-        'WI4MPI_RUN_MPIIO_F_LIB': str(run_f_lib),
-    }
-
-    LOGGER.debug("Wi4MPI environment: %s", env)
-    for key, value in env.items():
-        os.environ[key] = value
+    wi4mpi_prepare_environment_preload(
+        parameters.wi4mpi,
+        translation[0],
+        family_metadata,
+        mpi_install_dir,
+        run_c_lib,
+        run_f_lib,
+    )
 
     # Add the Wi4MPI --from --to options
     wi4mpi_bin_path = parameters.wi4mpi / 'bin'
@@ -214,6 +196,7 @@ class LaunchCommand(AbstractCommand):
             usage=usage,
             description=self.summary,
         )
+
         parser.add_argument(
             '--profile',
             type=arguments.single_defined_object(Profile, 'name'),
@@ -266,15 +249,14 @@ class LaunchCommand(AbstractCommand):
             metavar='installation',
         )
 
-        mpi_families = set(map(lambda x: x.cli_name, WI4MPI_METADATA))
         parser.add_argument(
             '--from',
             type=str.lower,
-            choices=mpi_families,
+            choices=WI4MPI_SOURCES,
             help=
             "MPI family the command was intended to be run. Use this argument "
             "to toggle MPI call translation. Available families: " +
-            ", ".join(mpi_families),
+            ", ".join(WI4MPI_SOURCES),
             default=arguments.SUPPRESS,
             metavar='mpi-family',
         )
@@ -285,6 +267,7 @@ class LaunchCommand(AbstractCommand):
             metavar='command',
             nargs=arguments.REMAINDER,
         )
+
         return parser
 
     def main(self, argv):
@@ -294,16 +277,16 @@ class LaunchCommand(AbstractCommand):
             LOGGER.info("Using selected profile %s", args.profile.get('name'))
 
         if not args.cmd:
-            self.parser.error("No command given")
+            self.parser.error("No executable was specified.")
 
         # Merge profile and cli arguments to get a definitive list of arguments
         parameters = _parameters(args)
 
         # Ensure the minimum fields required for launch are present
-        for field in ['backend', 'image']:
-            if not getattr(parameters, field, None):
+        for _field in ['backend', 'image']:
+            if not getattr(parameters, _field, None):
                 self.parser.error(
-                    f"Missing field: '{field}'. Specify it using the "
+                    f"Missing field: '{_field}'. Specify it using the "
                     "appropriate option or by selecting a profile.")
 
         launcher, program = interpret(args.cmd)
@@ -312,9 +295,12 @@ class LaunchCommand(AbstractCommand):
             if path not in parameters.files:
                 parameters.files.add(path)
 
+        wi4mpi_call = []
+
         binary_mpi_family = getattr(args, 'from', None)
         profile_mpi_libraries = filter_mpi_libs(parameters.libraries)
         profile_mpi_family = detect_mpi(profile_mpi_libraries)
+        profile_mpi_family_data = wi4mpi_get_metadata(profile_mpi_family)
 
         if profile_mpi_family:
             LOGGER.debug(
@@ -323,28 +309,28 @@ class LaunchCommand(AbstractCommand):
             )
         else:
             LOGGER.debug(
-                "No single MPI family could be detected in the parameters")
+                "No MPI family could be identified from the parameters")
 
-        translation = (binary_mpi_family, wi4mpi_qualifier(profile_mpi_family))
-        wi4mpi_call = []
-        if translation in SUPPORTED_TRANSLATIONS:
-            target_mpi_data = wi4mpi_identify(profile_mpi_family.vendor)
-            wi4mpi_call = _setup_wi4mpi(
-                parameters,
-                translation,
-                target_mpi_data,
-                profile_mpi_libraries,
-            )
+        if profile_mpi_family_data:
+            translation = (binary_mpi_family, profile_mpi_family_data.cli_name)
+            if translation in SUPPORTED_TRANSLATIONS:
+                wi4mpi_call = _setup_wi4mpi(
+                    parameters,
+                    translation,
+                    profile_mpi_family_data,
+                    profile_mpi_libraries,
+                )
 
-            # Relay the environment if OpenMPI is used
-            if (profile_mpi_family.vendor == "Open MPI"
-                    and Path(launcher[0]).name == "mpirun"):
-                launcher += shlex.split("-x WI4MPI_ROOT "
-                                        f"-x {target_mpi_data.path_key} "
-                                        "-x WI4MPI_RUN_MPI_C_LIB "
-                                        "-x WI4MPI_RUN_MPI_F_LIB "
-                                        "-x WI4MPI_RUN_MPIIO_C_LIB "
-                                        "-x WI4MPI_RUN_MPIIO_F_LIB")
+                # Explicitly pass the environment if OpenMPI is used
+                if (profile_mpi_family.vendor == "Open MPI"
+                        and Path(launcher[0]).name == "mpirun"):
+                    launcher += shlex.split(
+                        "-x WI4MPI_ROOT "
+                        f"-x {profile_mpi_family_data.path_key} "
+                        "-x WI4MPI_RUN_MPI_C_LIB "
+                        "-x WI4MPI_RUN_MPI_F_LIB "
+                        "-x WI4MPI_RUN_MPIIO_C_LIB "
+                        "-x WI4MPI_RUN_MPIIO_F_LIB")
 
         execute_command = _format_execute(parameters)
         full_command = [*launcher, *wi4mpi_call, *execute_command, *program]

--- a/e4s_cl/cli/commands/launch.py
+++ b/e4s_cl/cli/commands/launch.py
@@ -105,7 +105,7 @@ def _format_execute(parameters: Parameters) -> List[str]:
     if logger.debug_mode():
         execute_command = [execute_command[0], '-v'] + execute_command[1:]
 
-    for attr in ['image', 'backend', 'source', 'wi4mpi']:
+    for attr in ['image', 'backend', 'source']:
         value = getattr(parameters, attr, None)
         if value:
             execute_command += [f"--{attr}", str(value)]

--- a/e4s_cl/cli/commands/launch.py
+++ b/e4s_cl/cli/commands/launch.py
@@ -45,6 +45,7 @@ from e4s_cl.cf.detect_mpi import (
 from e4s_cl.cf.wi4mpi import (
     MPIFamily,
     SUPPORTED_TRANSLATIONS,
+    WI4MPI_ENVIRONMENT_VARIABLES,
     WI4MPI_METADATA,
     WI4MPI_SOURCES,
     wi4mpi_find_libraries,
@@ -335,13 +336,9 @@ class LaunchCommand(AbstractCommand):
                 # Explicitly pass the environment if OpenMPI's launcher is used
                 if (profile_mpi_family.vendor == "Open MPI"
                         and Path(launcher[0]).name == "mpirun"):
-                    launcher += shlex.split(
-                        "-x WI4MPI_ROOT "
-                        f"-x {profile_mpi_family_data.path_key} "
-                        "-x WI4MPI_RUN_MPI_C_LIB "
-                        "-x WI4MPI_RUN_MPI_F_LIB "
-                        "-x WI4MPI_RUN_MPIIO_C_LIB "
-                        "-x WI4MPI_RUN_MPIIO_F_LIB")
+                    for varname in WI4MPI_ENVIRONMENT_VARIABLES:
+                        if varname in os.environ.keys():
+                            launcher.extend(shlex.split(f"-x {varname}"))
 
         execute_command = _format_execute(parameters)
         full_command = [*launcher, *wi4mpi_call, *execute_command, *program]

--- a/e4s_cl/cli/commands/launch.py
+++ b/e4s_cl/cli/commands/launch.py
@@ -29,8 +29,13 @@ from pathlib import Path
 from argparse import Namespace
 from typing import Tuple, List, Optional
 from dataclasses import (dataclass, field)
-from e4s_cl import EXIT_SUCCESS, E4S_CL_SCRIPT
-from e4s_cl import logger, variables
+from e4s_cl import (
+    E4S_CL_SCRIPT,
+    EXIT_SUCCESS,
+    config,
+    logger,
+    variables,
+)
 from e4s_cl.cli import arguments
 from e4s_cl.util import run_e4scl_subprocess
 from e4s_cl.cli.command import AbstractCommand
@@ -135,7 +140,9 @@ def _setup_wi4mpi(
 
     # Locate the Wi4MPI installation and store it in parameters
     if parameters.wi4mpi is None:
-        wi4mpi_install = install_wi4mpi()
+        target_dir = Path(config.CONFIGURATION.wi4mpi_install_directory)
+        LOGGER.debug("Target: %s", target_dir)
+        wi4mpi_install = install_wi4mpi(target_dir)
         if wi4mpi_install:
             parameters.wi4mpi = wi4mpi_install
         else:

--- a/e4s_cl/config.py
+++ b/e4s_cl/config.py
@@ -14,6 +14,7 @@ from e4s_cl import (
     E4S_CL_TEST,
     EXIT_FAILURE,
     PROFILE_LIST_DEFAULT_COLUMNS,
+    WI4MPI_DEFAULT_INSTALL_DIR,
 )
 
 
@@ -227,6 +228,18 @@ ALLOWED_CONFIG = ConfigurationGroup(
             bool,
             lambda: False,
             "Disable logging on the work nodes",
+        ),
+        ConfigurationGroup(
+            "wi4mpi",
+            {
+                ConfigurationField(
+                    "install_directory",
+                    str,
+                    lambda: str(WI4MPI_DEFAULT_INSTALL_DIR),
+                    "Location of the Wi4MPI installation to use. If the directory does not exist, e4s-cl will attempt to install Wi4MPI in that directory.",
+                )
+            },
+            "Wi4MPI-related configuration options",
         ),
         ConfigurationGroup(
             "backends", {

--- a/e4s_cl/util.py
+++ b/e4s_cl/util.py
@@ -10,7 +10,7 @@ import subprocess
 from subprocess import DEVNULL, STDOUT
 import pkgutil
 from pathlib import Path
-import hashlib
+from hashlib import sha256
 import json
 from typing import (
     Any,
@@ -18,6 +18,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Union,
 )
 from functools import lru_cache, reduce
 from shutil import which as sh_which
@@ -392,17 +393,19 @@ def _iter_modules(paths, prefix):
             yield importer, name, ispkg
 
 
-def flatten(nested_list):
+def flatten(nested_list: List[List[Any]]) -> List[Any]:
     """Flatten a nested list."""
     return [item for sublist in nested_list for item in sublist]
 
 
-def hash256(string):
+def hash256(data: Union[bytes, str]) -> str:
     """
     Create a hash from a string
     """
-    grinder = hashlib.sha256()
-    grinder.update(string.encode())
+    grinder = sha256()
+    if isinstance(data, str):
+        data = data.encode()
+    grinder.update(data)
     return grinder.hexdigest()
 
 


### PR DESCRIPTION
Allow the use of `interface` on the launch command line to use Wi4MPI's interface mode.