### PR TITLE
Prevent double binds

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,7 @@ v1.0.2
 - Added default configuration output from command line
 - Improved podman support for container version detection
 - Fixed termcolor error on container failure
+- Add check to ensure symlinks are not bound twice
 
 v1.0.1 (Nov 10 2022)
 ---------------------

--- a/e4s_cl/cf/containers/__init__.py
+++ b/e4s_cl/cf/containers/__init__.py
@@ -66,12 +66,12 @@ class FileOptions:
     READ_WRITE = 1
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True)  # Frozen to take advantage of the hashing capacities
 class BoundFile:
     """Element of the bound file dictionnary"""
     origin: Path
     destination: Path
-    option: int
+    option: int = FileOptions.READ_ONLY
 
 
 class BackendError(ConfigurationError):

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,8 +1,12 @@
-from unittest import skipIf
 from pathlib import Path
 import tests
-from e4s_cl.cf.containers import (Container, BackendUnsupported, FileOptions,
-                                  BoundFile, optimize_bind_addition)
+from e4s_cl.cf.containers import (
+    BackendUnsupported,
+    BoundFile,
+    Container,
+    FileOptions,
+    optimize_bind_addition,
+)
 
 
 class ContainerTest(tests.TestCase):
@@ -93,3 +97,16 @@ class ContainerTest(tests.TestCase):
         files = set(map(lambda x: x.origin, container.bound))
 
         self.assertSetEqual({ref, file}, files)
+
+    def test_double_bind(self):
+        container = Container(name='dummy')
+
+        library = Path(tests.ASSETS, 'libgver.so.0')
+        library_symlink = Path(tests.ASSETS, 'libgver.so.0.0.0')
+        target = Path('/', 'hostlibs', 'libgver.so.0')
+
+        bind1 = BoundFile(library, target)
+        bind2 = BoundFile(library_symlink, target)
+
+        self.assertSetEqual({bind1}, optimize_bind_addition(bind2, {bind1}))
+        self.assertSetEqual({bind2}, optimize_bind_addition(bind1, {bind2}))


### PR DESCRIPTION
Assert a file binding destination does not conflict with a previous bind when adding files to a container. Aims to fix #107.