### PR TITLE
launchers: Added support for concatenated arguments

### DIFF
--- a/e4s_cl/cf/launchers/__init__.py
+++ b/e4s_cl/cf/launchers/__init__.py
@@ -61,12 +61,28 @@ class Parser:
         while known and position < len(command):
             flag = command[position]
 
-            if flag in self.arguments.keys():
+            if flag in self.arguments:
                 to_skip = self.arguments[flag]
 
             # Catch generic --flag=value
             elif re.match(r'^--[\-A-Za-z0-9]+=.*$', flag):
                 to_skip = 0
+
+            # Catch concatenated flag and value, -p gpu => -pgpu
+            # We know flag is not in self.arguments
+            elif re.match(r'^-[\w\-]+', flag):
+                # List arguments that match the start of flag and that take only one option
+                matches = list(
+                    filter(
+                        lambda option: (flag.startswith(option) and self.
+                                        arguments[option] == 1),
+                        self.arguments))
+
+                if (matches):
+                    to_skip = 0
+                else:
+                    known = False
+                    break
 
             else:
                 known = False

--- a/tests/test_launchers.py
+++ b/tests/test_launchers.py
@@ -126,6 +126,16 @@ class LauncherTest(tests.TestCase):
         self.assertEqual(valid, "-a test -c ofi btl".split())
         self.assertEqual(foreign, "-b 1 2 3 -d host1:2,host2:2".split())
 
+    def test_concat_arguments(self):
+        """
+        Check concatenated argument support
+        """
+        text = "srun -n4 -pgpu -Acourses01-gpu command"
+        launcher, command = interpret(split(text))
+
+        self.assertEqual(launcher, ['srun', '-n4', '-pgpu', '-Acourses01-gpu'])
+        self.assertEqual(command, ['command'])
+
     def test_additional_options_config(self):
         """Check configuration options get added to the launcher command"""
         command = ['mpirun', '-np', '4', './foo', '--bar']


### PR DESCRIPTION
Add another check when parsing the command line to ensure flags with no space are caught.