### PR TITLE
No rm ssl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,6 @@ $(CONDA): $(CONDA_SRC)
 	@bash $< -b -u -p $(CONDA_DEST)
 	@touch $(CONDA_BIN)/*
 	@# The following libraries are RPATH'ed and outdated - preventing the use of ctype in python code. Remove them to use the system's.
-	@rm $(CONDA_DEST)/lib/libcrypto*
 
 $(CONDA_SRC):
 	$(MKDIR) `dirname "$(CONDA_SRC)"`

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ $(CONDA): $(CONDA_SRC)
 	@bash $< -b -u -p $(CONDA_DEST)
 	@touch $(CONDA_BIN)/*
 	@# The following libraries are RPATH'ed and outdated - preventing the use of ctype in python code. Remove them to use the system's.
-	@rm $(CONDA_DEST)/lib/libssl* $(CONDA_DEST)/lib/libcrypto*
+	@rm $(CONDA_DEST)/lib/libcrypto*
 
 $(CONDA_SRC):
 	$(MKDIR) `dirname "$(CONDA_SRC)"`

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ all: install completion man
 $(CONDA): $(CONDA_SRC)
 	@bash $< -b -u -p $(CONDA_DEST)
 	@touch $(CONDA_BIN)/*
-	@# The following libraries are RPATH'ed and outdated - preventing the use of ctype in python code. Remove them to use the system's.
 
 $(CONDA_SRC):
 	$(MKDIR) `dirname "$(CONDA_SRC)"`


### PR DESCRIPTION
Removed the deletion of libcrypto and libssl as them missing usually breaks building e4s-cl.