### PR TITLE
Demo script, file mapping, wi4mpi fixes and mpi-confusion fixes

### DIFF
--- a/e4s_cl/__init__.py
+++ b/e4s_cl/__init__.py
@@ -103,11 +103,10 @@ SYSTEM_PREFIX = os.path.realpath(
                        os.path.join(E4S_CL_HOME, 'system'))))
 """str: System-level E4S Container Launcher files."""
 
-USER_PREFIX = os.path.realpath(
-    os.path.abspath(
-        os.environ.get(
-            '__E4S_CL_USER_PREFIX__',
-            os.path.join(os.path.expanduser('~'), '.local', 'e4s_cl'))))
+USER_PREFIX = os.path.abspath(
+    os.environ.get(
+        '__E4S_CL_USER_PREFIX__',
+        os.path.join(os.path.expanduser('~'), '.local', 'e4s_cl')))
 """str: User-level E4S Container Launcher files."""
 
 _CONTAINER_DIR_ENV = os.environ.get("E4S_CL_CONTAINER_DIR") or os.environ.get("E4S_CL_CONTAINER_DIRECTORY")

--- a/e4s_cl/__init__.py
+++ b/e4s_cl/__init__.py
@@ -66,8 +66,6 @@ E4S_CL_ENV_PREFIX = 'E4S_CL'
 
 def _get_e4s_cl_script():
     """Get a reliable path to the e4s-cl script for subprocess invocation."""
-    import sys
-    import os
     import shutil
     
     # First try the environment variable

--- a/e4s_cl/__init__.py
+++ b/e4s_cl/__init__.py
@@ -64,7 +64,32 @@ for system-level package installation paths. **Do not** change it once it is set
 
 E4S_CL_ENV_PREFIX = 'E4S_CL'
 
-E4S_CL_SCRIPT = os.environ.get('__E4S_CL_SCRIPT__', sys.argv[0] or 'e4s-cl')
+def _get_e4s_cl_script():
+    """Get a reliable path to the e4s-cl script for subprocess invocation."""
+    import sys
+    import os
+    import shutil
+    
+    # First try the environment variable
+    if '__E4S_CL_SCRIPT__' in os.environ:
+        script = os.environ['__E4S_CL_SCRIPT__']
+        # If it's just a command name, try to resolve it to a full path
+        if not os.path.isabs(script) and not os.path.exists(script):
+            # Try to find it in PATH
+            resolved = shutil.which(script)
+            if resolved:
+                return resolved
+        return script
+    
+    # Try using sys.argv[0] if it's available
+    script_candidate = sys.argv[0] or ''
+    if script_candidate:
+        return script_candidate
+    
+    # Fallback to just 'e4s-cl'
+    return 'e4s-cl'
+
+E4S_CL_SCRIPT = _get_e4s_cl_script()
 """str: Script that launched E4S Container Launcher.
 
 Mainly used for help messages. **Do not** change it once it is set.
@@ -87,7 +112,8 @@ USER_PREFIX = os.path.realpath(
             os.path.join(os.path.expanduser('~'), '.local', 'e4s_cl'))))
 """str: User-level E4S Container Launcher files."""
 
-CONTAINER_DIR = Path("/", ".e4s-cl").as_posix()
+_CONTAINER_DIR_ENV = os.environ.get("E4S_CL_CONTAINER_DIR") or os.environ.get("E4S_CL_CONTAINER_DIRECTORY")
+CONTAINER_DIR = Path(_CONTAINER_DIR_ENV).as_posix() if _CONTAINER_DIR_ENV else Path("/", ".e4s-cl").as_posix()
 """str: Path of a directory in which to bind files when in containers"""
 
 CONTAINER_SCRIPT = Path(CONTAINER_DIR, "script").as_posix()

--- a/e4s_cl/cf/trace.py
+++ b/e4s_cl/cf/trace.py
@@ -49,12 +49,13 @@ def opened_files(command):
                 event = debugger.waitSyscall()
             except ProcessExit as event:
                 return_code = event.exitcode
-                # When a process exits (especially in MPI with multiple processes),
-                # the debugger may still have other processes. Check if we should continue.
-                if len(debugger.dict) > 0:
-                    continue
-                else:
-                    break
+                # When a process exits in a multi-process MPI run, we need to check
+                # if there are other active processes remaining. The exiting process
+                # may still be in debugger.dict at this point, so check if there are
+                # processes other than the one that just exited.
+                # Note: while debugger checks len(debugger.list), which tracks active processes.
+                # If the loop continues (debugger is still truthy), we can continue tracing.
+                continue
             except ProcessSignal as event:
                 event.process.syscall(event.signum)
                 continue

--- a/e4s_cl/cf/trace.py
+++ b/e4s_cl/cf/trace.py
@@ -49,7 +49,12 @@ def opened_files(command):
                 event = debugger.waitSyscall()
             except ProcessExit as event:
                 return_code = event.exitcode
-                continue
+                # When a process exits (especially in MPI with multiple processes),
+                # the debugger may still have other processes. Check if we should continue.
+                if len(debugger.dict) > 0:
+                    continue
+                else:
+                    break
             except ProcessSignal as event:
                 event.process.syscall(event.signum)
                 continue

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -286,6 +286,11 @@ def wi4mpi_preload(install_dir: Path, container_library_dir: str = None) -> List
     NOTE: The fake libraries (fakelib{FROM}/) go in LD_LIBRARY_PATH, NOT in LD_PRELOAD.
     This matches the official Wi4MPI launcher script behavior.
     
+    IMPORTANT: When container_library_dir is provided, this function assumes the target
+    MPI libraries (WI4MPI_RUN_MPI_C_LIB and WI4MPI_RUN_MPI_F_LIB) have already been
+    imported into the container at that location. The caller must ensure import_library()
+    is called before this function when running in container mode.
+    
     Args:
         install_dir: Path to Wi4MPI installation directory
         container_library_dir: The path where host libraries are mounted inside

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -169,10 +169,14 @@ def wi4mpi_root() -> Optional[Path]:
 
     if string is None or not string:
         LOGGER.debug("Getting Wi4MPI root failed - WI4MPI_ROOT not in environment")
-        LOGGER.debug(f"Available Wi4MPI env vars: WI4MPI_FROM={os.environ.get('WI4MPI_FROM')}, WI4MPI_TO={os.environ.get('WI4MPI_TO')}")
+        LOGGER.debug(
+            "Available Wi4MPI env vars: WI4MPI_FROM=%s, WI4MPI_TO=%s",
+            os.environ.get("WI4MPI_FROM"),
+            os.environ.get("WI4MPI_TO"),
+        )
         return None
 
-    LOGGER.debug(f"Wi4MPI root found: {string}")
+    LOGGER.debug("Wi4MPI root found: %s", string)
     return Path(string)
 
 

--- a/e4s_cl/cf/wi4mpi/__init__.py
+++ b/e4s_cl/cf/wi4mpi/__init__.py
@@ -168,9 +168,11 @@ def wi4mpi_root() -> Optional[Path]:
     string = os.environ.get("WI4MPI_ROOT")
 
     if string is None or not string:
-        LOGGER.debug("Getting Wi4MPI root failed")
+        LOGGER.debug("Getting Wi4MPI root failed - WI4MPI_ROOT not in environment")
+        LOGGER.debug(f"Available Wi4MPI env vars: WI4MPI_FROM={os.environ.get('WI4MPI_FROM')}, WI4MPI_TO={os.environ.get('WI4MPI_TO')}")
         return None
 
+    LOGGER.debug(f"Wi4MPI root found: {string}")
     return Path(string)
 
 
@@ -268,23 +270,61 @@ def wi4mpi_libpath(install_dir: Path):
             yield Path(filename)
 
 
-def wi4mpi_preload(install_dir: Path) -> List[str]:
+def wi4mpi_preload(install_dir: Path, container_library_dir: str = None) -> List[str]:
     """
     Returns a list of libraries to preload for WI4MPI
+    
+    Preload order follows Wi4MPI's official script:
+    1. The Wi4MPI translation library (libwi4mpi_{FROM}_{TO}.so) - intercepts MPI calls
+    2. The target MPI Fortran library (WI4MPI_RUN_MPI_F_LIB) - provides symbols for translation
+    3. The target MPI C library (WI4MPI_RUN_MPI_C_LIB) - provides symbols like ompi_mpi_char
+    
+    NOTE: The fake libraries (fakelib{FROM}/) go in LD_LIBRARY_PATH, NOT in LD_PRELOAD.
+    This matches the official Wi4MPI launcher script behavior.
+    
+    Args:
+        install_dir: Path to Wi4MPI installation directory
+        container_library_dir: The path where host libraries are mounted inside
+            the container (e.g., '/.e4s-cl/hostlibs'). Required for container execution.
     """
     to_preload = []
 
-    # Pass along the preloaded libraries from wi4mpi
-    for file in os.environ.get("LD_PRELOAD", "").split():
-        to_preload.append(file)
-
     source = os.environ.get("WI4MPI_FROM", "")
+    target = os.environ.get("WI4MPI_TO", "")
 
-    fakelib_dir = install_dir / 'libexec' / 'wi4mpi' / f"fakelib{source}"
+    # 1. Add the translation library FIRST
+    if source and target:
+        translation_lib = install_dir / 'libexec' / 'wi4mpi' / f"libwi4mpi_{source}_{target}.so"
+        if translation_lib.exists():
+            to_preload.append(translation_lib.as_posix())
+            LOGGER.debug("Wi4MPI: Adding translation library to preload: %s", translation_lib)
+        else:
+            LOGGER.warning("Wi4MPI translation library not found: %s", translation_lib)
 
-    if fakelib_dir.exists():
-        for file in fakelib_dir.glob('lib*'):
-            to_preload.append(file.as_posix())
+    # 2. Add the target MPI F library (provides Fortran symbols)
+    target_mpi_f_lib = os.environ.get("WI4MPI_RUN_MPI_F_LIB", "")
+    if target_mpi_f_lib and Path(target_mpi_f_lib).exists():
+        if container_library_dir:
+            container_path = Path(container_library_dir) / Path(target_mpi_f_lib).name
+            to_preload.append(container_path.as_posix())
+            LOGGER.debug("Wi4MPI: Adding target MPI F library to preload (container path): %s", container_path)
+        else:
+            to_preload.append(target_mpi_f_lib)
+            LOGGER.debug("Wi4MPI: Adding target MPI F library to preload: %s", target_mpi_f_lib)
+
+    # 3. Add the target MPI C library (provides C symbols like ompi_mpi_char)
+    target_mpi_c_lib = os.environ.get("WI4MPI_RUN_MPI_C_LIB", "")
+    if target_mpi_c_lib and Path(target_mpi_c_lib).exists():
+        if container_library_dir:
+            container_path = Path(container_library_dir) / Path(target_mpi_c_lib).name
+            to_preload.append(container_path.as_posix())
+            LOGGER.debug("Wi4MPI: Adding target MPI C library to preload (container path): %s", container_path)
+        else:
+            to_preload.append(target_mpi_c_lib)
+            LOGGER.debug("Wi4MPI: Adding target MPI C library to preload: %s", target_mpi_c_lib)
+
+    # NOTE: Fake libraries are NOT preloaded - they go in LD_LIBRARY_PATH
+    # (handled by wi4mpi_libpath function)
 
     return to_preload
 

--- a/e4s_cl/cf/wi4mpi/install.py
+++ b/e4s_cl/cf/wi4mpi/install.py
@@ -214,6 +214,16 @@ def install_wi4mpi(install_dir: Path) -> Optional[Path]:
         source_dir.as_posix(),
     ]
 
+    # Apply custom CFLAGS/CXXFLAGS if provided via environment variables
+    wi4mpi_cflags = os.environ.get('E4S_CL_WI4MPI_CFLAGS')
+    wi4mpi_cxxflags = os.environ.get('E4S_CL_WI4MPI_CXXFLAGS')
+    if wi4mpi_cflags:
+        configure_cmd.append(f"-DCMAKE_C_FLAGS={wi4mpi_cflags}")
+        LOGGER.debug("Using custom Wi4MPI CFLAGS: %s", wi4mpi_cflags)
+    if wi4mpi_cxxflags:
+        configure_cmd.append(f"-DCMAKE_CXX_FLAGS={wi4mpi_cxxflags}")
+        LOGGER.debug("Using custom Wi4MPI CXXFLAGS: %s", wi4mpi_cxxflags)
+
     build_cmd = [
         cmake_executable,
         "--build",

--- a/e4s_cl/cf/wi4mpi/install.py
+++ b/e4s_cl/cf/wi4mpi/install.py
@@ -26,6 +26,7 @@ from e4s_cl.cf.compiler import (
     VENDOR_BINARIES,
     available_compilers,
 )
+from elftools.elf.elffile import ELFFile
 
 LOGGER = get_logger(__name__)
 
@@ -157,27 +158,77 @@ def _double_tap(cmd):
     return not success
 
 
+def _check_wi4mpi_install(install_dir: Path) -> bool:
+    """
+    Sanity check for the Wi4MPI installation
+    """
+    # Check binary existence
+    binary = install_dir / 'bin' / 'wi4mpi'
+    if not binary.exists():
+        LOGGER.debug("Wi4MPI binary not found at %s", binary)
+        return False
+
+    # Check architecture of shares objects
+    # Expected machine from os.uname().machine
+    machine = os.uname().machine
+    expected = {
+        'x86_64': 'EM_X86_64',
+        'amd64': 'EM_X86_64',
+        'aarch64': 'EM_AARCH64',
+        'ppc64le': 'EM_PPC64',
+        'ppc64': 'EM_PPC64',
+    }.get(machine)
+
+    if expected:
+        # Check libexec shared objects
+        lib_dir = install_dir / 'libexec' / 'wi4mpi'
+        libraries = list(lib_dir.glob('libwi4mpi_*.so'))
+
+        if libraries:
+            for lib in libraries:
+                if not lib.is_file():
+                    continue
+                try:
+                    with open(lib, 'rb') as f:
+                        elf = ELFFile(f)
+                        if elf.header.e_machine != expected:
+                            LOGGER.error(
+                                "Wi4MPI library %s architecture mismatch: expected %s, got %s",
+                                lib.name, expected, elf.header.e_machine)
+                            return False
+                except Exception as err:
+                    LOGGER.debug("Failed to check architecture of %s: %s", lib,
+                                 err)
+
+    # Check if executable runs
+    if run_subprocess([str(binary), '-h'], discard_output=True):
+        LOGGER.error("Wi4MPI binary at %s failed to run", binary)
+        return False
+
+    return True
+
+
 def install_wi4mpi(install_dir: Path) -> Optional[Path]:
     """Clones and installs wi4mpi from github releases"""
 
-    if os.uname().machine not in {'x86_64', 'amd64', 'aarch64'}:
+    if os.uname().machine not in {'x86_64', 'amd64', 'aarch64', 'ppc64le'}:
         LOGGER.warning(
             "Wi4MPI not available for the following architecture: %s",
             os.uname().machine)
         return None
 
-    binary = install_dir / 'bin' / 'wi4mpi'
-    if install_dir.exists() and binary.exists():
-        LOGGER.debug(
-            "Skipping installation for already installed Wi4MPI in %s",
-            install_dir)
-        return install_dir
+    if install_dir.exists():
+        if _check_wi4mpi_install(install_dir):
+            LOGGER.debug(
+                "Skipping installation for already installed Wi4MPI in %s",
+                install_dir)
+            return install_dir
 
-    if install_dir.exists() and list(install_dir.glob('*')):
-        LOGGER.error(
-            "Attempting Wi4MPI installation in a non-empty directory: %s",
-            str(install_dir))
-        return None
+        if list(install_dir.glob('*')):
+            LOGGER.error(
+                "Target directory %s is not empty and contains an invalid or incomplete Wi4MPI installation.",
+                install_dir)
+            return None
 
     # Assert CMake is available
     cmake_executable = which("cmake")

--- a/e4s_cl/cf/wi4mpi/install.py
+++ b/e4s_cl/cf/wi4mpi/install.py
@@ -191,10 +191,13 @@ def _check_wi4mpi_install(install_dir: Path) -> bool:
                 try:
                     with open(lib, 'rb') as f:
                         elf = ELFFile(f)
-                        if elf.header.e_machine != expected:
+                        # Note: With pyelftools 0.27, header['e_machine'] returns a string like 'EM_X86_64'
+                        # Both elf.header.e_machine and elf.header['e_machine'] work equivalently
+                        machine_type = elf.header['e_machine']
+                        if machine_type != expected:
                             LOGGER.error(
                                 "Wi4MPI library %s architecture mismatch: expected %s, got %s",
-                                lib.name, expected, elf.header.e_machine)
+                                lib.name, expected, machine_type)
                             return False
                 except Exception as err:
                     LOGGER.debug("Failed to check architecture of %s: %s", lib,

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -534,7 +534,8 @@ class ExecuteCommand(AbstractCommand):
                 import_library(Library.from_path(Path(host_mpi_f_lib)), container)
                 container_mpi_f_lib = Path(container.import_library_dir) / Path(host_mpi_f_lib).name
                 params.extra_env["WI4MPI_RUN_MPI_F_LIB"] = container_mpi_f_lib.as_posix()
-                params.extra_env["WI4MPI_RUN_MPIIO_C_LIB"] = container_mpi_lib.as_posix()
+                if host_mpi_lib:
+                    params.extra_env["WI4MPI_RUN_MPIIO_C_LIB"] = container_mpi_lib.as_posix()
                 params.extra_env["WI4MPI_RUN_MPIIO_F_LIB"] = container_mpi_f_lib.as_posix()
 
         # Write the entry script to a file, then bind it to the container

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -524,12 +524,14 @@ class ExecuteCommand(AbstractCommand):
             # the container path where host libraries are bound
             host_mpi_lib = os.environ.get("WI4MPI_RUN_MPI_C_LIB", "")
             if host_mpi_lib:
+                import_library(Library.from_path(Path(host_mpi_lib)), container)
                 container_mpi_lib = Path(container.import_library_dir) / Path(host_mpi_lib).name
                 params.extra_env["WI4MPI_RUN_MPI_C_LIB"] = container_mpi_lib.as_posix()
                 LOGGER.debug("Wi4MPI: Overriding WI4MPI_RUN_MPI_C_LIB to container path: %s", container_mpi_lib)
             
             host_mpi_f_lib = os.environ.get("WI4MPI_RUN_MPI_F_LIB", "")
             if host_mpi_f_lib:
+                import_library(Library.from_path(Path(host_mpi_f_lib)), container)
                 container_mpi_f_lib = Path(container.import_library_dir) / Path(host_mpi_f_lib).name
                 params.extra_env["WI4MPI_RUN_MPI_F_LIB"] = container_mpi_f_lib.as_posix()
                 params.extra_env["WI4MPI_RUN_MPIIO_C_LIB"] = container_mpi_lib.as_posix()

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -467,13 +467,20 @@ class ExecuteCommand(AbstractCommand):
                 parts = path.split(':')
                 if len(parts) == 2:
                     source, dest = parts
+                else:
+                    LOGGER.error("Invalid file binding specification '%s'. Expected 'source:dest'.", path)
+                    continue
 
-            if dest and _check_access(source):
-                container.bind_file(source, dest=dest, option=FileOptions.READ_WRITE)
-            elif _check_access(path):
-                container.bind_file(path, option=FileOptions.READ_WRITE)
+            if dest is not None:
+                if _check_access(source):
+                    container.bind_file(source, dest=dest, option=FileOptions.READ_WRITE)
+                else:
+                    LOGGER.error("File '%s' not found.", source)
             else:
-                LOGGER.error("File '%s' not found.", source)
+                if _check_access(path):
+                    container.bind_file(path, option=FileOptions.READ_WRITE)
+                else:
+                    LOGGER.error("File '%s' not found.", path)
 
         # This script is sourced before any other command in the container
         params.source_script_path = args.source

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -468,10 +468,10 @@ class ExecuteCommand(AbstractCommand):
                 if len(parts) == 2:
                     source, dest = parts
 
-            if _check_access(path):
-                container.bind_file(path, option=FileOptions.READ_WRITE)
-            elif dest and _check_access(source):
+            if dest and _check_access(source):
                 container.bind_file(source, dest=dest, option=FileOptions.READ_WRITE)
+            elif _check_access(path):
+                container.bind_file(path, option=FileOptions.READ_WRITE)
             else:
                 LOGGER.error("File '%s' not found.", source)
 

--- a/e4s_cl/cli/commands/__execute.py
+++ b/e4s_cl/cli/commands/__execute.py
@@ -404,7 +404,7 @@ class ExecuteCommand(AbstractCommand):
                             metavar='files')
 
         parser.add_argument('--libraries',
-                            type=arguments.existing_posix_path_list,
+                            type=arguments.posix_path_list,
                             help="Libraries to bind, comma-separated",
                             default=[],
                             metavar='libraries')
@@ -445,6 +445,18 @@ class ExecuteCommand(AbstractCommand):
         # The following is a set of all libraries required. It
         # is used in the container to check version mismatches
         required_libraries = [*args.libraries, *wi4mpi_required]
+
+        # Filter out libraries that don't exist on this node. This can happen
+        # in multi-node launches where filesystems differ across nodes (e.g.
+        # ROCm libs present on some nodes but not others).
+        available_libraries = []
+        for lib_path in required_libraries:
+            if Path(lib_path).exists():
+                available_libraries.append(lib_path)
+            else:
+                LOGGER.warning("Library '%s' not found on this node, skipping",
+                               lib_path)
+        required_libraries = available_libraries
         
         # NOTE: Do NOT filter OpenMPI core libraries (libmpi.so.40, libopen-pal.so.40, etc.)
         # when Wi4MPI is active - Wi4MPI needs these to translate MPICH->OpenMPI calls.

--- a/e4s_cl/cli/commands/launch.py
+++ b/e4s_cl/cli/commands/launch.py
@@ -349,7 +349,7 @@ class LaunchCommand(AbstractCommand):
         launcher, program = interpret(args.cmd)
 
         for path in get_reserved_directories(launcher):
-            if path not in parameters.files:
+            if path.exists() and path not in parameters.files:
                 parameters.files.add(path)
 
         wi4mpi_call = []

--- a/e4s_cl/cli/commands/profile/detect.py
+++ b/e4s_cl/cli/commands/profile/detect.py
@@ -286,9 +286,20 @@ def _filter_mpi_artifacts(libs: List[Path], files: List[Path],
     launcher = resolved_launcher.resolve()
 
     def _get_lib_prefix(path: Path) -> Path:
+        """Extract installation prefix from library path.
+        
+        Looks for 'lib' or 'lib64' directory markers to determine the prefix.
+        For example, /opt/mpich/lib/libmpi.so -> /opt/mpich
+        Falls back to parent directory for non-standard layouts.
+        """
         for marker in ['lib', 'lib64']:
             if marker in path.parts:
-                return Path(*path.parts[:path.parts.index(marker)])
+                marker_idx = path.parts.index(marker)
+                # Ensure marker is a directory component, not the filename
+                if marker_idx < len(path.parts) - 1:
+                    return Path(*path.parts[:marker_idx])
+        # Fallback: use parent directory for non-standard layouts
+        # This handles cases like /custom/path/libmpi.so
         return path.parent
 
     def _is_core_mpi(path: Path) -> bool:

--- a/e4s_cl/cli/commands/profile/detect.py
+++ b/e4s_cl/cli/commands/profile/detect.py
@@ -48,7 +48,7 @@ from e4s_cl import (EXIT_SUCCESS, EXIT_FAILURE, E4S_CL_SCRIPT, logger,
 from e4s_cl import variables
 from e4s_cl.error import ProfileSelectionError
 from e4s_cl.util import (run_e4scl_subprocess, flatten, json_dumps, json_loads,
-                         path_contains, apply_filters)
+                         path_contains, apply_filters, which)
 from e4s_cl.cf.trace import opened_files
 from e4s_cl.cf.launchers import interpret, get_reserved_directories
 from e4s_cl.cli import arguments
@@ -102,6 +102,9 @@ def filter_files(path_list: List[Path],
             if path_contains(entry, path):
                 return False
         return True
+
+    def _not_root(path: Path) -> bool:
+        return path != Path('/')
 
     def _existence(path: Path) -> bool:
         """Assert the file still exists and is accessible"""
@@ -162,7 +165,7 @@ def filter_files(path_list: List[Path],
     orphan_libraries = elf_objects - libraries
 
     filtered_files = set(
-        apply_filters([_not_cache, _not_blacklisted, _waived_launcher],
+        apply_filters([_not_cache, _not_blacklisted, _not_root, _waived_launcher],
                       regular_files))
     files = filtered_files.union(orphan_libraries)
 
@@ -208,16 +211,183 @@ def save_to_profile(profile_name, libraries, files) -> int:
     return EXIT_SUCCESS
 
 
+CORE_MPI_PREFIXES = (
+    'libmpi',
+    'libmpich',
+    'libopen-rte',
+    'liborte',
+    'liboshmem',
+)
+
+
+def _filter_mpi_artifacts(libs: List[Path], files: List[Path],
+                          launcher: Path,
+                          mpi_filter: str = 'auto',
+                          exclude_prefixes: List[str] = None,
+                          exclude_names: List[str] = None) -> (List[str], List[str]):
+    """
+    Filter MPI-related artifacts using one of three modes:
+      - off: no filtering (trust ptrace)
+      - manual: apply user exclusions only
+      - auto: infer authoritative MPI from libmpi and launcher prefix
+
+    Manual exclusions are always applied before MPI filtering.
+    Filtering fails open on ambiguity.
+    """
+    if not libs or not launcher:
+        return [str(p) for p in libs], [str(p) for p in files]
+
+    if mpi_filter == 'off':
+        return [str(p) for p in libs], [str(p) for p in files]
+
+    exclude_prefixes = exclude_prefixes or []
+    exclude_names = exclude_names or []
+
+    # Normalize exclude prefixes
+    normalized_exclude_prefixes = [Path(p).resolve() for p in exclude_prefixes]
+
+    # Warn if exclusions are used in auto mode
+    if mpi_filter == 'auto' and (exclude_prefixes or exclude_names):
+        LOGGER.warning(
+            "Manual exclusions are applied before MPI auto-filtering. "
+            "Consider --mpi-filter=manual if this is intentional."
+        )
+
+    # Handle manual exclusions first, regardless of auto/manual mode
+    if normalized_exclude_prefixes or exclude_names:
+        kept_libs = []
+        for lib in libs:
+            resolved = lib.resolve()
+            excluded = False
+            if resolved.name in exclude_names:
+                excluded = True
+
+            if not excluded:
+                for prefix in normalized_exclude_prefixes:
+                    if path_contains(prefix, resolved):
+                        excluded = True
+                        break
+
+            if excluded:
+                LOGGER.info("Excluding user-blacklisted artifact %s", lib)
+                continue
+            kept_libs.append(lib)
+        libs = kept_libs
+
+    if mpi_filter == 'manual':
+        return [str(p) for p in libs], [str(p) for p in files]
+
+    resolved_launcher = launcher
+    if not launcher.is_absolute():
+        path_str = which(str(launcher))
+        if path_str:
+            resolved_launcher = Path(path_str)
+
+    launcher = resolved_launcher.resolve()
+
+    def _get_lib_prefix(path: Path) -> Path:
+        for marker in ['lib', 'lib64']:
+            if marker in path.parts:
+                return Path(*path.parts[:path.parts.index(marker)])
+        return path.parent
+
+    def _is_core_mpi(path: Path) -> bool:
+        name = path.name
+        return any(name.startswith(prefix) for prefix in CORE_MPI_PREFIXES)
+
+    resolved_libs = [lib.resolve() for lib in libs]
+
+    # 1. Identify authoritative libmpi candidates
+    candidates = list(set([
+        lib for lib in resolved_libs
+        if lib.name == 'libmpi.so' or lib.name.startswith('libmpi.so.')
+    ]))
+
+    if not candidates:
+        return [str(p) for p in libs], [str(p) for p in files]
+
+    # Check for system launcher
+    is_system_launcher = str(launcher).startswith('/usr/bin') or str(launcher).startswith('/bin')
+
+    selected_lib = None
+
+    if is_system_launcher:
+        if len(candidates) == 1:
+            selected_lib = candidates[0]
+        else:
+             # Ambiguity or 0 -> fail open
+             return [str(p) for p in libs], [str(p) for p in files]
+    else:
+        # Standard launcher
+        if len(candidates) == 1:
+            selected_lib = candidates[0]
+        else:
+            # Multiple candidates. Filter by overlap with launcher prefix.
+            launcher_prefix = launcher.parent
+            if 'bin' in launcher.parts:
+                 launcher_prefix = Path(*launcher.parts[:launcher.parts.index('bin')])
+
+            matches = []
+            for cand in candidates:
+                 cand_prefix = _get_lib_prefix(cand)
+                 # Check overlap
+                 if (launcher_prefix == cand_prefix or
+                     launcher_prefix in cand_prefix.parents or
+                     cand_prefix in launcher_prefix.parents):
+                     matches.append(cand)
+
+            if len(matches) == 1:
+                selected_lib = matches[0]
+            else:
+                 # No match or Multiple matches -> Fail open
+                 return [str(p) for p in libs], [str(p) for p in files]
+
+    # We have a selected authoritative library
+    selected_prefix = _get_lib_prefix(selected_lib)
+
+    LOGGER.info("MPI filtering mode: %s", mpi_filter)
+    LOGGER.info("Authoritative MPI: %s", selected_lib)
+
+    kept_libs = []
+    discarded_libs = []
+
+    for lib in libs:
+        resolved = lib.resolve()
+
+        # Keep non-core libraries always (whitelist)
+        if not _is_core_mpi(resolved):
+            kept_libs.append(lib)
+            continue
+
+        # For core libs, check prefix consistency with authoritative lib
+        lib_prefix = _get_lib_prefix(resolved)
+
+        if (selected_prefix == lib_prefix or
+            selected_prefix in lib_prefix.parents or
+            lib_prefix in selected_prefix.parents):
+             kept_libs.append(lib)
+        else:
+             LOGGER.info("Discarding MPI artifact %s (prefix mismatch with %s)", lib, selected_lib)
+             discarded_libs.append(lib)
+
+    if discarded_libs:
+        LOGGER.info("Discarded core MPI libs: %s", [l.name for l in discarded_libs])
+
+    return [str(p) for p in kept_libs], [str(p) for p in files]
+
+
 def detect_subprocesses(launcher, program):
     """Run process profiling in subprocesses with the detected launcher"""
     files, libs = [], []
 
     os.environ[LAUNCHER_VAR] = launcher[0]
     # If a launcher is present, act as a launcher
+    # Use a timeout to prevent hanging on mpirun with multiple processes
     return_code, json_data = run_e4scl_subprocess([
         *launcher, sys.executable, E4S_CL_SCRIPT, "profile", "detect", *program
     ],
-                                                  capture_output=True)
+                                                  capture_output=True,
+                                                  timeout=60)
 
     if return_code:
         LOGGER.error(
@@ -261,6 +431,22 @@ class ProfileDetectCommand(AbstractCliView):
                             help="Executable command, e.g. './a.out'",
                             metavar='command',
                             nargs=arguments.REMAINDER)
+        
+        parser.add_argument('--mpi-filter',
+                            help="Filter mode for MPI artifacts (default: auto)",
+                            choices=['auto', 'off', 'manual'],
+                            default='auto')
+        
+        parser.add_argument('--exclude-lib-prefix',
+                            help="Exclude libraries under this prefix when --mpi-filter=manual",
+                            action='append',
+                            default=[])
+
+        parser.add_argument('--exclude-lib-name',
+                            help="Exclude libraries with this exact name when --mpi-filter=manual",
+                            action='append',
+                            default=[])
+
         return parser
 
     def main(self, argv):
@@ -273,6 +459,15 @@ class ProfileDetectCommand(AbstractCliView):
 
         if launcher:
             libs, files = detect_subprocesses(launcher, program)
+
+            # Filter out artifacts from other MPI implementations
+            libs, files = _filter_mpi_artifacts([Path(l) for l in libs],
+                                                [Path(f) for f in files],
+                                                Path(launcher[0]),
+                                                mpi_filter=getattr(args, 'mpi_filter', 'auto'),
+                                                exclude_prefixes=getattr(args, 'exclude_lib_prefix', []),
+                                                exclude_names=getattr(args, 'exclude_lib_name', [])
+                                                )
         else:
             launcher = os.environ.get(LAUNCHER_VAR, '').split(' ')
 

--- a/e4s_cl/cli/commands/profile/detect.py
+++ b/e4s_cl/cli/commands/profile/detect.py
@@ -123,6 +123,13 @@ def filter_files(path_list: List[Path],
         return True
 
     valid_files = set(filter(_existence, path_list))
+
+    # Apply blacklist and root filters BEFORE is_elf to avoid opening device
+    # nodes (e.g. /dev/dri/renderD*) which block on open(), and to skip
+    # thousands of /sys/ entries that are never ELF shared libraries.
+    valid_files = set(
+        apply_filters([_not_blacklisted, _not_root], valid_files))
+
     elf_objects = set(filter(is_elf, valid_files))
     regular_files = valid_files - elf_objects
 
@@ -165,7 +172,7 @@ def filter_files(path_list: List[Path],
     orphan_libraries = elf_objects - libraries
 
     filtered_files = set(
-        apply_filters([_not_cache, _not_blacklisted, _not_root, _waived_launcher],
+        apply_filters([_not_cache, _waived_launcher],
                       regular_files))
     files = filtered_files.union(orphan_libraries)
 
@@ -393,12 +400,18 @@ def detect_subprocesses(launcher, program):
 
     os.environ[LAUNCHER_VAR] = launcher[0]
     # If a launcher is present, act as a launcher
-    # Use a timeout to prevent hanging on mpirun with multiple processes
+    # Use a timeout to prevent hanging on mpirun with multiple processes.
+    # The timeout is configurable via __E4S_CL_DETECT_TIMEOUT (seconds).
+    # Default is 120s to accommodate srun job-scheduling overhead.
+    try:
+        detect_timeout = int(os.environ.get('__E4S_CL_DETECT_TIMEOUT', '120'))
+    except ValueError:
+        detect_timeout = 120
     return_code, json_data = run_e4scl_subprocess([
         *launcher, sys.executable, E4S_CL_SCRIPT, "profile", "detect", *program
     ],
                                                   capture_output=True,
-                                                  timeout=60)
+                                                  timeout=detect_timeout)
 
     if return_code:
         LOGGER.error(

--- a/e4s_cl/cli/commands/profile/edit.py
+++ b/e4s_cl/cli/commands/profile/edit.py
@@ -62,7 +62,7 @@ class ProfileEditCommand(EditCommand):
                             default=arguments.SUPPRESS)
 
         parser.add_argument('--add-files',
-                            help="Add files to the profile",
+                            help="Add files to the profile. Supports host:container syntax.",
                             metavar='<file>',
                             nargs='+',
                             type=arguments.posix_path,

--- a/e4s_cl/util.py
+++ b/e4s_cl/util.py
@@ -19,6 +19,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Union,
 )
 from functools import lru_cache, reduce
@@ -193,7 +194,7 @@ def run_subprocess(cmd, cwd=None, env=None, discard_output=False) -> int:
     return returncode
 
 
-def run_e4scl_subprocess(cmd, cwd=None, env=None, capture_output=False, timeout=None) -> int:
+def run_e4scl_subprocess(cmd, cwd=None, env=None, capture_output=False, timeout=None) -> Tuple[int, str]:
     """
     cmd: list[str],
     env: Optional[dict],

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -285,7 +285,7 @@ run_timed() {
   local end
   end=$(python3 -c 'import time; print(time.time())')
   local duration
-  duration=$(python3 -c "print(f'{${end} - ${start}:.3f}')")
+  duration=$(python3 -c "print('{:.3f}'.format(${end} - ${start}))")
 
   # Use flock or simple append (pipe serialization usually handles simple appends)
   printf "%s %s\n" "${label}" "${duration}" >> "${out_file}"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,707 @@
+#!/usr/bin/env bash
+# High-level e4s-cl validation script
+# - Starts from a clean, local build of e4s-cl
+# - Uses apptainer + MPI-enabled container image
+# - Primary focus: run a container-built MPI app using the host MPI
+# - Also captures host baseline and optional in-container baseline
+# - Compares host vs e4s-cl launch vs container-only performance
+#
+# Notes:
+# - Primary use case: portable container apps should leverage optimized host MPI.
+# - Reverse (host-built app inside container) is useful but secondary.
+# - Cross-scheduler support (host and container differ) is future work.
+#
+# Usage:
+#   ./scripts/demo.sh [options]
+#   ./scripts/demo.sh --help
+#
+# Host MPI notes:
+# - Typical host MPI stacks: MPICH, Open MPI, MVAPICH2, Intel MPI, Cray MPICH.
+# - If installing with Spack, ensure mpicc/mpirun are in PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+E4S_CL_IMAGE=""
+E4S_CL_PROFILE_NAME="HOST_MPI"
+E4S_CL_MPI_PROCS="2"
+E4S_CL_OSU_URL="https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.9.tar.gz"
+E4S_CL_MODE="full"
+E4S_CL_TAG=""
+E4S_CL_WORKDIR="${REPO_ROOT}/_e4scl_test"
+E4S_CL_CACHE_DIR="${REPO_ROOT}/_e4scl_cache"
+E4S_CL_KEEP_WORKDIR="1"
+E4S_CL_BUILD_IMAGE="0"
+E4S_CL_IMAGE_OUTPUT="${E4S_CL_CACHE_DIR}/e4s-cl-mpich.sif"
+E4S_CL_IMAGE_DEF=""
+E4S_CL_REBUILD_IMAGE="0"
+E4S_CL_APPTAINER_BUILD_ARGS=""
+E4S_CL_RUN_HOST_BASELINE="1"
+E4S_CL_RUN_CONTAINER_BASELINE="0"
+E4S_CL_PRUNE_INTEL_OPENCL="0"
+E4S_CL_SKIP_PROFILE_DETECT="0"
+E4S_CL_WI4MPI_CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=format -Wno-error=int-conversion -Wno-error=return-type -include string.h -include sys/time.h"
+E4S_CL_APPTAINER_EXEC_OPTIONS=""
+E4S_CL_CONTAINER_DIR="/tmp/.e4s-cl"
+E4S_CL_HOST_MPI=""
+E4S_CL_HOST_MPIRUN=""
+E4S_CL_LAUNCHER=""
+E4S_CL_SCHEDULER=""
+E4S_CL_E4SCL_LAUNCH_ARGS=""
+E4S_CL_TIMEOUT_DURATION="60s"
+
+log() { printf "[e4s-cl-test] %s\n" "$*"; }
+fail() { printf "[e4s-cl-test] ERROR: %s\n" "$*" >&2; exit 1; }
+
+DOC_TODO_FILE="${REPO_ROOT}/documentation.TODO"
+doc_todo() {
+  local note="$1"
+  if [[ ! -f "${DOC_TODO_FILE}" ]]; then
+    printf "# Documentation TODOs (auto-collected)\n" > "${DOC_TODO_FILE}"
+  fi
+  if ! grep -Fq "${note}" "${DOC_TODO_FILE}"; then
+    printf -- "- %s\n" "${note}" >> "${DOC_TODO_FILE}"
+  fi
+}
+
+usage() {
+  cat <<EOF
+High-level e4s-cl validation script
+
+Usage:
+  ./scripts/demo.sh [options]
+
+Options:
+  --image <path|uri>           Apptainer image path (.sif) or URI (docker://...) (default: none)
+  --build-image                Build a local MPICH apptainer image (default: off)
+  --image-output <path>        Output image path (default: _e4scl_cache_<tag>/e4s-cl-mpich-<tag>.sif)
+  --image-def <path>           Custom apptainer definition file (default: auto-generated)
+  --rebuild-image              Force rebuild of image when --build-image is set (default: off)
+  --apptainer-build-args <arg> Extra args for apptainer build (default: --fakeroot)
+  --profile-name <name>        Profile name to use (default: HOST_MPI)
+  --mpi-procs <n>              MPI ranks (default: 2)
+  --osu-url <url>              OSU benchmarks tarball URL (default: https://mvapich.cse.ohio-state.edu/download/mvapich/osu-micro-benchmarks-5.9.tar.gz)
+  --mode <light|full>          Light: latency/bw tests (shorter). Full: adds allreduce + full range (default: full)
+  --tag <name>                 Artifact tag used for work/cache paths (default: auto)
+  --workdir <path>             Working directory (default: _e4scl_test_<tag>)
+  --cache-dir <path>           Cache directory (default: _e4scl_cache_<tag>)
+  --clean-workdir              Delete workdir on exit (default: off)
+  --host-baseline <on|off>     Run host-only baseline (default: on)
+  --container-baseline <on|off> Run container-only baseline (default: off)
+  --no-prune-intel-opencl      Disable workaround that prunes Intel/OpenCL libs from profile (default: pruning enabled)
+  --skip-profile-detect        Skip profile detect if profile already has bindings (default: off)
+  --wi4mpi-cflags "..."         Extra C/C++ flags for Wi4MPI build (default: relax GCC 14 errors)
+  --apptainer-exec-options "..." Extra apptainer exec options (default: none)
+  --container-dir <path>       Container data dir (default: /tmp/.e4s-cl)
+  --host-mpicc <path>          Override host mpicc (default: auto-detect)
+  --host-mpirun <path>         Override host mpirun/mpiexec (default: auto-detect)
+  --launcher <cmd>             Force launcher (mpirun or srun) (default: auto-detect)
+  --scheduler <name>           If "slurm", use srun when available (default: none)
+  --e4scl-launch-args "..."     Extra args for e4s-cl launch (default: none)
+  --timeout <duration>         Timeout for MPI runs (default: 60s)
+  --check                      Check environment prerequisites and exit
+  -h, --help                   Show help
+
+Examples:
+  ./scripts/demo.sh --image /path/to/mpi.sif --mode light
+  ./scripts/demo.sh --build-image --mode light --host-baseline off
+  ./scripts/demo.sh --image docker://ecpe4s/e4s-mpi-cpu-x86_64:v4.3.1-1762472545 --mode light
+EOF
+}
+
+parse_bool() {
+  case "${1,,}" in
+    1|true|yes|on) echo "1" ;;
+    0|false|no|off) echo "0" ;;
+    *) fail "Invalid boolean value: $1 (use on/off, true/false, 1/0)" ;;
+  esac
+}
+
+sanitize_tag() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's#[^a-z0-9._-]+#-#g' | sed -E 's/^-+|-+$//g'
+}
+
+derive_tag() {
+  local base=""
+  local suffix="-${E4S_CL_MODE}-np${E4S_CL_MPI_PROCS}"
+  if [[ -n "${E4S_CL_IMAGE}" ]]; then
+    base="${E4S_CL_IMAGE##*/}"
+    base="${base%.sif}"
+    base="${base//:/-}"
+    # Avoid duplicating the suffix if it's already in the image name
+    if [[ "${base}" == *"${suffix}" ]]; then
+      base="${base%"${suffix}"}"
+    fi
+  elif [[ "${E4S_CL_BUILD_IMAGE}" == "1" ]]; then
+    base="local-mpich"
+  else
+    base="default"
+  fi
+  echo "${base}${suffix}"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --image) E4S_CL_IMAGE="$2"; shift 2 ;;
+    --build-image) E4S_CL_BUILD_IMAGE="1"; shift ;;
+    --image-output) E4S_CL_IMAGE_OUTPUT="$2"; shift 2 ;;
+    --image-def) E4S_CL_IMAGE_DEF="$2"; shift 2 ;;
+    --rebuild-image) E4S_CL_REBUILD_IMAGE="1"; shift ;;
+    --apptainer-build-args) E4S_CL_APPTAINER_BUILD_ARGS="$2"; shift 2 ;;
+    --profile-name) E4S_CL_PROFILE_NAME="$2"; shift 2 ;;
+    --mpi-procs) E4S_CL_MPI_PROCS="$2"; shift 2 ;;
+    --osu-url) E4S_CL_OSU_URL="$2"; shift 2 ;;
+    --mode) E4S_CL_MODE="$2"; shift 2 ;;
+    --tag) E4S_CL_TAG="$2"; shift 2 ;;
+    --workdir) E4S_CL_WORKDIR="$2"; shift 2 ;;
+    --cache-dir) E4S_CL_CACHE_DIR="$2"; shift 2 ;;
+    --clean-workdir) E4S_CL_KEEP_WORKDIR="0"; shift ;;
+    --host-baseline) E4S_CL_RUN_HOST_BASELINE="$(parse_bool "$2")"; shift 2 ;;
+    --container-baseline) E4S_CL_RUN_CONTAINER_BASELINE="$(parse_bool "$2")"; shift 2 ;;
+    --no-prune-intel-opencl) E4S_CL_PRUNE_INTEL_OPENCL="0"; shift ;;
+    --skip-profile-detect) E4S_CL_SKIP_PROFILE_DETECT="1"; shift ;;
+    --wi4mpi-cflags) E4S_CL_WI4MPI_CFLAGS="$2"; shift 2 ;;
+    --apptainer-exec-options) E4S_CL_APPTAINER_EXEC_OPTIONS="$2"; shift 2 ;;
+    --container-dir) E4S_CL_CONTAINER_DIR="$2"; shift 2 ;;
+    --run-host-baseline) E4S_CL_RUN_HOST_BASELINE="1"; shift ;;
+    --skip-host-baseline) E4S_CL_RUN_HOST_BASELINE="0"; shift ;;
+    --run-container-baseline) E4S_CL_RUN_CONTAINER_BASELINE="1"; shift ;;
+    --skip-container-baseline) E4S_CL_RUN_CONTAINER_BASELINE="0"; shift ;;
+    --host-mpicc) E4S_CL_HOST_MPI="$2"; shift 2 ;;
+    --host-mpirun) E4S_CL_HOST_MPIRUN="$2"; shift 2 ;;
+    --launcher) E4S_CL_LAUNCHER="$2"; shift 2 ;;
+    --scheduler) E4S_CL_SCHEDULER="$2"; shift 2 ;;
+    --e4scl-launch-args) E4S_CL_E4SCL_LAUNCH_ARGS="$2"; shift 2 ;;
+    --timeout) E4S_CL_TIMEOUT_DURATION="$2"; shift 2 ;;
+    --check) E4S_CL_ONLY_CHECK="1"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) fail "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || fail "Missing required command: $1"
+}
+
+check_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+if [[ "${E4S_CL_ONLY_CHECK:-0}" == "1" ]]; then
+  log "Checking environment..."
+  
+  MISSING=0
+  
+  log "Checking Python..."
+  if check_cmd python3; then
+     log "  Found: $(command -v python3) ($(python3 --version))"
+  else
+     log "  MISSING: python3"
+     MISSING=1
+  fi
+  
+  log "Checking Container Runtime..."
+  if check_cmd apptainer; then
+     log "  Found: $(command -v apptainer) ($(apptainer --version))"
+  elif check_cmd singularity; then
+     log "  Found: $(command -v singularity) ($(singularity --version))"
+  else
+     log "  MISSING: apptainer or singularity"
+     MISSING=1
+  fi
+  
+  log "Checking MPI..."
+  if check_cmd mpicc; then
+     log "  Found: $(command -v mpicc)"
+  else
+     log "  MISSING: mpicc (common in default environments, but needed for tests)"
+     MISSING=1
+  fi
+  
+  if check_cmd mpirun; then
+     log "  Found: $(command -v mpirun)"
+  else
+     log "  MISSING: mpirun"
+     MISSING=1
+  fi
+  
+  log "Checking Utilities..."
+  for tool in curl tar make gcc timeout; do
+    if check_cmd "$tool"; then
+       log "  Found: $tool"
+    else
+       log "  MISSING: $tool"
+       MISSING=1
+    fi
+  done
+  
+  if [[ "$MISSING" -eq 1 ]]; then
+     fail "One or more prerequisites missing."
+  else
+     log "Environment looks good!"
+     exit 0
+  fi
+fi
+
+DEFAULT_WORKDIR="${REPO_ROOT}/_e4scl_test"
+DEFAULT_CACHE_DIR="${REPO_ROOT}/_e4scl_cache"
+if [[ -z "${E4S_CL_TAG}" ]]; then
+  E4S_CL_TAG="$(sanitize_tag "$(derive_tag)")"
+fi
+if [[ "${E4S_CL_WORKDIR}" == "${DEFAULT_WORKDIR}" ]]; then
+  E4S_CL_WORKDIR="${DEFAULT_WORKDIR}_${E4S_CL_TAG}"
+fi
+if [[ "${E4S_CL_CACHE_DIR}" == "${DEFAULT_CACHE_DIR}" ]]; then
+  E4S_CL_CACHE_DIR="${DEFAULT_CACHE_DIR}_${E4S_CL_TAG}"
+fi
+if [[ "${E4S_CL_IMAGE_OUTPUT}" == "${DEFAULT_CACHE_DIR}/e4s-cl-mpich.sif" ]]; then
+  E4S_CL_IMAGE_OUTPUT="${E4S_CL_CACHE_DIR}/e4s-cl-mpich-${E4S_CL_TAG}.sif"
+fi
+
+run_timed() {
+  local label="$1"
+  shift
+  local cmd=("$@")
+  local out_file="${E4S_CL_WORKDIR}/timing.dat"
+
+  log "Running [${label}]..."
+  # Use python for distinct wall-clock measurement
+  local start
+  start=$(python3 -c 'import time; print(time.time())')
+
+  set +e
+  timeout "${E4S_CL_TIMEOUT_DURATION}" "${cmd[@]}"
+  local ret=$?
+  set -e
+
+  if [[ $ret -eq 124 ]]; then
+    fail "Command timed out (${E4S_CL_TIMEOUT_DURATION}): ${cmd[*]}"
+  elif [[ $ret -ne 0 ]]; then
+    fail "Command failed (exit $ret): ${cmd[*]}"
+  fi
+
+  local end
+  end=$(python3 -c 'import time; print(time.time())')
+  local duration
+  duration=$(python3 -c "print(f'{${end} - ${start}:.3f}')")
+
+  # Use flock or simple append (pipe serialization usually handles simple appends)
+  printf "%s %s\n" "${label}" "${duration}" >> "${out_file}"
+}
+
+detect_mpi_family() {
+  local text="$1"
+  local lowered
+  lowered=$(echo "$text" | tr 'A-Z' 'a-z')
+  if echo "$lowered" | grep -q "open mpi"; then
+    echo "openmpi"
+  elif echo "$lowered" | grep -q "mvapich"; then
+    echo "mvapich"
+  elif echo "$lowered" | grep -q "intel"; then
+    echo "intelmpi"
+  elif echo "$lowered" | grep -q "cray mpich"; then
+    echo "mpich"
+  elif echo "$lowered" | grep -q "hydra"; then
+    echo "mpich"
+  elif echo "$lowered" | grep -q "mpich"; then
+    echo "mpich"
+  else
+    echo ""
+  fi
+}
+
+log "Validating prerequisites"
+require_cmd python3
+require_cmd curl
+require_cmd tar
+require_cmd make
+require_cmd gcc
+
+if check_cmd apptainer; then
+  CONTAINER_CMD="apptainer"
+  log "Using Container Runtime: apptainer"
+elif check_cmd singularity; then
+  CONTAINER_CMD="singularity"
+  log "Using Container Runtime: singularity"
+else
+  fail "Neither apptainer nor singularity found. Install one and try again."
+fi
+
+if [[ "${E4S_CL_BUILD_IMAGE}" == "1" ]]; then
+  mkdir -p "${E4S_CL_CACHE_DIR}"
+  if [[ -z "${E4S_CL_IMAGE}" ]]; then
+    E4S_CL_IMAGE="${E4S_CL_IMAGE_OUTPUT}"
+  fi
+  if [[ "${E4S_CL_REBUILD_IMAGE}" == "1" || ! -f "${E4S_CL_IMAGE}" ]]; then
+    log "Building local MPICH container image: ${E4S_CL_IMAGE}"
+    if [[ -z "${E4S_CL_IMAGE_DEF}" ]]; then
+      HOST_ARCH="$(uname -m)"
+      case "${HOST_ARCH}" in
+        x86_64|amd64) BASE_IMAGE="ubuntu:22.04" ;;
+        aarch64|arm64) BASE_IMAGE="arm64v8/ubuntu:22.04" ;;
+        ppc64le) BASE_IMAGE="ppc64le/ubuntu:22.04" ;;
+        *)
+          BASE_IMAGE="ubuntu:22.04"
+          log "Unknown arch '${HOST_ARCH}', defaulting to ${BASE_IMAGE}"
+          doc_todo "Local image build defaults to ubuntu:22.04 for unknown arch (${HOST_ARCH}); document supported arches."
+          ;;
+      esac
+      E4S_CL_IMAGE_DEF="${E4S_CL_CACHE_DIR}/e4s-cl-mpich-${E4S_CL_TAG}.def"
+      cat > "${E4S_CL_IMAGE_DEF}" <<EOF
+Bootstrap: docker
+From: ${BASE_IMAGE}
+
+%post
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update
+  apt-get install -y --no-install-recommends \
+    mpich libmpich-dev \
+    build-essential gcc g++ gfortran make pkg-config file \
+    curl ca-certificates tar
+  apt-get clean
+  rm -rf /var/lib/apt/lists/*
+
+%environment
+  export PATH=/usr/bin:\$PATH
+EOF
+    fi
+
+    if [[ -z "${E4S_CL_APPTAINER_BUILD_ARGS}" ]]; then
+      E4S_CL_APPTAINER_BUILD_ARGS="--fakeroot"
+    fi
+    ${CONTAINER_CMD} build ${E4S_CL_APPTAINER_BUILD_ARGS} "${E4S_CL_IMAGE}" "${E4S_CL_IMAGE_DEF}"
+  fi
+fi
+
+[[ -n "${E4S_CL_IMAGE}" ]] || fail "--image is required or enable --build-image"
+if [[ "${E4S_CL_IMAGE}" != docker://* && "${E4S_CL_IMAGE}" != library://* ]]; then
+  [[ -f "${E4S_CL_IMAGE}" ]] || fail "E4S_CL_IMAGE not found: ${E4S_CL_IMAGE}"
+fi
+
+# Host MPI detection
+HOST_MPICC="${E4S_CL_HOST_MPI:-$(command -v mpicc || true)}"
+HOST_MPIRUN="${E4S_CL_HOST_MPIRUN:-$(command -v mpirun || command -v mpiexec || true)}"
+[[ -n "${HOST_MPICC}" ]] || fail "Host MPI compiler not found (mpicc)"
+[[ -n "${HOST_MPIRUN}" ]] || fail "Host MPI launcher not found (mpirun or mpiexec)"
+
+log "Container Runtime: $CONTAINER_CMD"
+log "Host MPI compiler: ${HOST_MPICC}"\
+"$("${HOST_MPICC}" --version | head -n 1 || true)"
+log "Host MPI launcher: ${HOST_MPIRUN}"\
+"$("${HOST_MPIRUN}" --version | head -n 1 || true)"
+
+LAUNCHER_BIN="${E4S_CL_LAUNCHER:-}"
+if [[ -z "${LAUNCHER_BIN}" && "${E4S_CL_SCHEDULER}" == "slurm" ]]; then
+  LAUNCHER_BIN="$(command -v srun || true)"
+fi
+if [[ -z "${LAUNCHER_BIN}" ]]; then
+  LAUNCHER_BIN="${HOST_MPIRUN}"
+fi
+
+if [[ "${LAUNCHER_BIN##*/}" == "srun" ]]; then
+  LAUNCHER_ARGS=("-n" "${E4S_CL_MPI_PROCS}")
+else
+  LAUNCHER_ARGS=("-np" "${E4S_CL_MPI_PROCS}")
+fi
+
+HOST_MPI_VERSION="$(${HOST_MPIRUN} --version 2>/dev/null | head -n 2 || true)"
+HOST_MPI_FAMILY="$(detect_mpi_family "${HOST_MPI_VERSION}")"
+CONTAINER_MPI_VERSION="$(${CONTAINER_CMD} exec "${E4S_CL_IMAGE}" mpirun --version 2>/dev/null | head -n 2 || true)"
+if [[ -z "$(detect_mpi_family "${CONTAINER_MPI_VERSION}")" ]]; then
+  CONTAINER_MPI_VERSION+=$'\n'"$(${CONTAINER_CMD} exec "${E4S_CL_IMAGE}" mpichversion 2>/dev/null | head -n 2 || true)"
+fi
+CONTAINER_MPI_FAMILY="$(detect_mpi_family "${CONTAINER_MPI_VERSION}")"
+
+log "Detected host MPI family: ${HOST_MPI_FAMILY:-unknown}"
+log "Detected container MPI family: ${CONTAINER_MPI_FAMILY:-unknown}"
+
+E4SCL_LAUNCH_ARGS=()
+if [[ -n "${E4S_CL_E4SCL_LAUNCH_ARGS}" ]]; then
+  read -r -a E4SCL_LAUNCH_ARGS <<< "${E4S_CL_E4SCL_LAUNCH_ARGS}"
+fi
+
+NEEDS_TRANSLATION="0"
+if printf '%s\n' "${E4SCL_LAUNCH_ARGS[@]}" | grep -q -- "--from"; then
+  NEEDS_TRANSLATION="1"
+elif [[ -n "${HOST_MPI_FAMILY}" && -n "${CONTAINER_MPI_FAMILY}" && "${HOST_MPI_FAMILY}" != "${CONTAINER_MPI_FAMILY}" ]]; then
+  log "MPI mismatch detected (host=${HOST_MPI_FAMILY}, container=${CONTAINER_MPI_FAMILY}); enabling Wi4MPI translation"
+  E4SCL_LAUNCH_ARGS=("--from" "${CONTAINER_MPI_FAMILY}" "${E4SCL_LAUNCH_ARGS[@]}")
+  NEEDS_TRANSLATION="1"
+  doc_todo "e4s-cl requires explicit --from when container MPI differs; add guidance to auto-detect and pass --from."
+fi
+
+log "Step 1: Setting up e4s-cl. Using a local virtual environment and editable install to ensure the latest code is used."
+if [[ ! -x "${REPO_ROOT}/.venv/bin/python" ]]; then
+  python3 -m venv "${REPO_ROOT}/.venv"
+fi
+"${REPO_ROOT}/.venv/bin/python" -m pip install -U pip
+"${REPO_ROOT}/.venv/bin/python" -m pip install -e "${REPO_ROOT}"
+
+E4S_CL_BIN="${REPO_ROOT}/.venv/bin/e4s-cl"
+[[ -x "${E4S_CL_BIN}" ]] || fail "e4s-cl not installed in venv"
+
+if [[ "${NEEDS_TRANSLATION}" == "1" ]]; then
+  log "Wi4MPI translation required; e4s-cl will install Wi4MPI during launch if missing"
+  if [[ -n "${E4S_CL_WI4MPI_CFLAGS}" ]]; then
+    log "CONFIG: injecting Wi4MPI build flags to ensure compatibility (e.g., GCC 14)"
+    log "CONFIG: CFLAGS/CXXFLAGS=${E4S_CL_WI4MPI_CFLAGS}"
+    export CFLAGS="${E4S_CL_WI4MPI_CFLAGS} ${CFLAGS:-}"
+    export CXXFLAGS="${E4S_CL_WI4MPI_CFLAGS} ${CXXFLAGS:-}"
+  fi
+fi
+
+if [[ -n "${E4S_CL_APPTAINER_EXEC_OPTIONS}" ]]; then
+  # Useful for complex container setups
+  log "CONFIG: setting E4S_CL_APPTAINER_EXEC_OPTIONS=${E4S_CL_APPTAINER_EXEC_OPTIONS}"
+  export E4S_CL_APPTAINER_EXEC_OPTIONS="${E4S_CL_APPTAINER_EXEC_OPTIONS}"
+fi
+
+if [[ -n "${E4S_CL_CONTAINER_DIR}" ]]; then
+  # Use a specific container directory relative to host environment
+  log "CONFIG: setting E4S_CL_CONTAINER_DIR=${E4S_CL_CONTAINER_DIR}"
+  export E4S_CL_CONTAINER_DIR="${E4S_CL_CONTAINER_DIR}"
+fi
+
+log "Preparing workdir: ${E4S_CL_WORKDIR}"
+mkdir -p "${E4S_CL_WORKDIR}"
+mkdir -p "${E4S_CL_CACHE_DIR}"
+
+log "Fetching OSU benchmarks"
+OSU_TARBALL="${E4S_CL_CACHE_DIR}/osu.tar.gz"
+OSU_SRC_DIR="${E4S_CL_WORKDIR}/osu"
+OSU_META_FILE="${E4S_CL_WORKDIR}/osu.meta"
+if [[ ! -f "${OSU_TARBALL}" || ! -f "${OSU_META_FILE}" ]]; then
+  curl -L "${E4S_CL_OSU_URL}" -o "${OSU_TARBALL}"
+  rm -rf "${OSU_SRC_DIR}"
+elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_META_FILE}"; then
+  curl -L "${E4S_CL_OSU_URL}" -o "${OSU_TARBALL}"
+  rm -rf "${OSU_SRC_DIR}"
+fi
+if [[ ! -d "${OSU_SRC_DIR}" ]]; then
+  mkdir -p "${OSU_SRC_DIR}"
+  tar -xzf "${OSU_TARBALL}" -C "${OSU_SRC_DIR}" --strip-components=1
+fi
+printf "osu_url=%s\n" "${E4S_CL_OSU_URL}" > "${OSU_META_FILE}"
+
+if [[ "${E4S_CL_MODE}" == "light" ]]; then
+  OSU_BENCHES=("pt2pt/osu_latency" "pt2pt/osu_bw")
+  OSU_ARGS=("-x" "10" "-i" "100" "-m" "8:1024")
+else
+  OSU_BENCHES=("pt2pt/osu_latency" "pt2pt/osu_bw" "collective/osu_allreduce")
+  OSU_ARGS=()
+fi
+
+if [[ "${E4S_CL_MPI_PROCS}" != "2" ]]; then
+  if printf '%s\n' "${OSU_BENCHES[@]}" | grep -q "pt2pt/osu_"; then
+    log "NOTE: pt2pt OSU benchmarks require exactly 2 processes (current: ${E4S_CL_MPI_PROCS})"
+  fi
+fi
+
+log "Step 2: Building Host Benchmarks. We compile OSU benchmarks on the host to 1) check host MPI health, 2) set a performance baseline, and 3) provide a binary for e4s-cl to analyze."
+OSU_HOST_PREFIX="${E4S_CL_WORKDIR}/osu-host"
+OSU_HOST_META="${OSU_HOST_PREFIX}/.build-meta"
+HOST_MPICC_VERSION="$(${HOST_MPICC} --version | head -n 1 || true)"
+REBUILD_HOST_OSU="0"
+if [[ ! -d "${OSU_HOST_PREFIX}" || ! -f "${OSU_HOST_META}" ]]; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "mpicc=${HOST_MPICC}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "mpicc_version=${HOST_MPICC_VERSION}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+fi
+
+if [[ "${REBUILD_HOST_OSU}" == "1" ]]; then
+  log "(Re)building host OSU benchmarks"
+  rm -rf "${OSU_HOST_PREFIX}"
+  mkdir -p "${OSU_HOST_PREFIX}"
+  (
+    cd "${OSU_SRC_DIR}"
+    ./configure CC="${HOST_MPICC}" --prefix="${OSU_HOST_PREFIX}"
+    make -j
+    make install
+  )
+  printf "mpicc=%s\nmpicc_version=%s\nosu_url=%s\n" "${HOST_MPICC}" "${HOST_MPICC_VERSION}" "${E4S_CL_OSU_URL}" > "${OSU_HOST_META}"
+else
+  log "Reusing host OSU benchmarks: ${OSU_HOST_PREFIX}"
+fi
+
+if [[ "${E4S_CL_RUN_HOST_BASELINE}" == "1" ]]; then
+  log "Step 2b: Running baseline host MPI benchmarks. This confirms the host MPI works and provides reference numbers."
+  for bench in "${OSU_BENCHES[@]}"; do
+    bench_name="$(basename "${bench}")"
+    out_file="${E4S_CL_WORKDIR}/host_${bench_name}.txt"
+    run_timed "host_${bench_name}" "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" \
+      "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/${bench}" \
+      "${OSU_ARGS[@]}" | tee "${out_file}"
+  done
+fi
+
+log "Step 3: Configuring e4s-cl Profile. A 'profile' stores metadata about the container backend, image, and the host libraries we want to inject."
+if ! "${E4S_CL_BIN}" profile create "${E4S_CL_PROFILE_NAME}" --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"; then
+  log "Profile exists, updating image/backend"
+  "${E4S_CL_BIN}" profile edit --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"
+fi
+"${E4S_CL_BIN}" profile select "${E4S_CL_PROFILE_NAME}"
+
+# Validate detection results; if empty, retry once and fail early with guidance.
+# This mirrors how a user would re-run detection when the profile isn't populated.
+profile_has_bindings() {
+  local output
+  output="$(${E4S_CL_BIN} profile show)"
+  if echo "${output}" | awk '/^Bound libraries:/{inlib=1; next} /^Bound files:/{inlib=0} inlib && /^ - /{print}' | grep -q .; then
+    return 0
+  fi
+  if echo "${output}" | awk '/^Bound files:/{infiles=1; next} infiles && /^ - /{print}' | grep -q .; then
+    return 0
+  fi
+  return 1
+}
+
+if [[ "${E4S_CL_SKIP_PROFILE_DETECT}" == "1" ]]; then
+  if profile_has_bindings; then
+    log "Skipping profile detect (--skip-profile-detect); using existing profile bindings"
+  else
+    log "WARNING: --skip-profile-detect specified but profile has no bindings; running detect anyway"
+    run_timed "detect" "${E4S_CL_BIN}" profile detect "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" -- "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency"
+  fi
+else
+  log "Step 4: Profile Analysis. e4s-cl traces the execution of a host binary to find all shared libraries and files needed to run MPI on this system."
+  run_timed "detect" "${E4S_CL_BIN}" profile detect "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" -- "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency"
+fi
+
+if ! profile_has_bindings; then
+  log "Profile detect produced no bound libraries/files; retrying once"
+  run_timed "detect_retry" "${E4S_CL_BIN}" profile detect "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" -- "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency"
+  if ! profile_has_bindings; then
+    fail "Profile detect produced no libraries/files. Verify launcher and MPI environment, then retry."
+  fi
+fi
+
+log "Step 5: Building Container Benchmarks. We compile the same benchmarks *inside* the container against the Container's MPI to demonstrate ABI compatibility or translation."
+OSU_CONT_PREFIX="${E4S_CL_WORKDIR}/osu-container"
+OSU_CONT_META="${OSU_CONT_PREFIX}/.build-meta"
+REBUILD_CONT_OSU="0"
+if [[ ! -d "${OSU_CONT_PREFIX}" || ! -f "${OSU_CONT_META}" ]]; then
+  REBUILD_CONT_OSU="1"
+elif ! grep -Fq "container_mpi=${CONTAINER_MPI_VERSION}" "${OSU_CONT_META}"; then
+  REBUILD_CONT_OSU="1"
+elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_CONT_META}"; then
+  REBUILD_CONT_OSU="1"
+fi
+
+if [[ "${REBUILD_CONT_OSU}" == "1" ]]; then
+  log "(Re)building container OSU benchmarks"
+  rm -rf "${OSU_CONT_PREFIX}"
+  mkdir -p "${OSU_CONT_PREFIX}"
+  ${CONTAINER_CMD} exec -B "${E4S_CL_WORKDIR}:/work" -B "${E4S_CL_CACHE_DIR}:/cache" "${E4S_CL_IMAGE}" bash -lc "\
+    set -euo pipefail; \
+    cd /work; \
+    rm -rf osu-container-build && mkdir osu-container-build; \
+    tar -xzf /cache/osu.tar.gz -C osu-container-build --strip-components=1; \
+    cd osu-container-build; \
+    ./configure CC=mpicc --prefix=/work/osu-container; \
+    make -j; \
+    make install; \
+  "
+  printf "container_mpi=%s\nosu_url=%s\n" "${CONTAINER_MPI_VERSION}" "${E4S_CL_OSU_URL}" > "${OSU_CONT_META}"
+else
+  log "Reusing container OSU benchmarks: ${OSU_CONT_PREFIX}"
+fi
+
+log "Step 6: MAIN TEST. Running the container-compiled binary using the Host's MPI. e4s-cl handles the library injection and launcher wrapping."
+for bench in "${OSU_BENCHES[@]}"; do
+  bench_name="$(basename "${bench}")"
+  out_file="${E4S_CL_WORKDIR}/e4scl_${bench_name}.txt"
+  run_timed "e4scl_${bench_name}" "${E4S_CL_BIN}" launch "${E4SCL_LAUNCH_ARGS[@]}" "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" \
+    "${OSU_CONT_PREFIX}/libexec/osu-micro-benchmarks/mpi/${bench}" \
+    "${OSU_ARGS[@]}" | tee "${out_file}"
+done
+
+if [[ "${E4S_CL_RUN_CONTAINER_BASELINE}" == "1" ]]; then
+  log "Step 7: Container Baseline. Running benchmarks using the Container's unoptimized MPI (if enabled). This compares 'native container' vs 'e4s-cl host MPI'."
+  for bench in "${OSU_BENCHES[@]}"; do
+    bench_name="$(basename "${bench}")"
+    out_file="${E4S_CL_WORKDIR}/container_${bench_name}.txt"
+    run_timed "container_${bench_name}" ${CONTAINER_CMD} exec -B "${E4S_CL_WORKDIR}:/work" "${E4S_CL_IMAGE}" bash -lc "\
+      mpirun -np ${E4S_CL_MPI_PROCS} /work/osu-container/libexec/osu-micro-benchmarks/mpi/${bench} ${OSU_ARGS[*]} \
+    " | tee "${out_file}"
+  done
+fi
+
+log "Done. Results saved in ${E4S_CL_WORKDIR}"
+log "  - Host Baseline: ${E4S_CL_WORKDIR}/host_*.txt"
+log "  - e4s-cl Run:    ${E4S_CL_WORKDIR}/e4scl_*.txt"
+if [[ "${E4S_CL_RUN_CONTAINER_BASELINE}" == "1" ]]; then
+log "  - Container Run: ${E4S_CL_WORKDIR}/container_*.txt"
+fi
+
+TIME_FILE="${E4S_CL_WORKDIR}/timing.dat"
+python3 -c "
+import sys
+import os
+
+def get_perf_val(filepath, bench_name):
+    try:
+        with open(filepath, 'r') as f:
+            lines = f.readlines()
+        
+        # Filter data lines
+        data_lines = [l.strip().split() for l in lines if l.strip() and l.strip()[0].isdigit()]
+        if not data_lines: return 'N/A'
+
+        if 'osu_bw' in bench_name:
+            # Bandwidth: return the value from the largest size (last line)
+            return data_lines[-1][1]
+        else:
+            # Latency (pt2pt or collective): return value for size 8
+            for row in data_lines:
+                if row[0] == '8':
+                    return row[1]
+            return 'N/A'
+    except Exception:
+        return 'N/A'
+
+time_data = {}
+try:
+    if os.path.exists('${TIME_FILE}'):
+        with open('${TIME_FILE}', 'r') as f:
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 2:
+                    time_data[parts[0]] = parts[1]
+except Exception:
+    pass
+
+benches = '${OSU_BENCHES[*]}'.split()
+workdir = '${E4S_CL_WORKDIR}'
+
+print('\n[e4s-cl-test] --- Results Summary ---')
+print(f'{\"Benchmark\":<20} {\"Metric (Size)\":<15} {\"Host\":<10} {\"E4S-CL\":<10} {\"Container\":<10}')
+
+for b in benches:
+    b_name = os.path.basename(b)
+    
+    # Timing
+    h_time = time_data.get(f'host_{b_name}', 'N/A')
+    e_time = time_data.get(f'e4scl_{b_name}', 'N/A')
+    c_time = time_data.get(f'container_{b_name}', 'off')
+    
+    # Performance
+    metric_label = 'Latency (8B)'
+    if 'osu_bw' in b_name:
+        metric_label = 'BW (Max)'
+        
+    h_perf = get_perf_val(os.path.join(workdir, f'host_{b_name}.txt'), b_name)
+    e_perf = get_perf_val(os.path.join(workdir, f'e4scl_{b_name}.txt'), b_name)
+    c_perf = 'off'
+    if c_time != 'off':
+        c_perf = get_perf_val(os.path.join(workdir, f'container_{b_name}.txt'), b_name)
+
+    print(f'{b_name:<20} {\"Time (s)\":<15} {h_time:<10} {e_time:<10} {c_time:<10}')
+    print(f'{\" \":<20} {metric_label:<15} {h_perf:<10} {e_perf:<10} {c_perf:<10}')
+    print('-' * 70)
+"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -417,6 +417,16 @@ CONTAINER_MPI_FAMILY="$(detect_mpi_family "${CONTAINER_MPI_VERSION}")"
 log "Detected host MPI family: ${HOST_MPI_FAMILY:-unknown}"
 log "Detected container MPI family: ${CONTAINER_MPI_FAMILY:-unknown}"
 
+# Best-effort heads-up for the Open MPI CMA user-namespace warning that shows up
+# when the host MPI is Open MPI and we run ranks inside an apptainer/singularity
+# user namespace (non-setuid). In that case the `vader` BTL drops to memcpy and
+# emits a cma-different-user-namespace warning; bandwidth/latency dip is normal.
+if [[ "${HOST_MPI_FAMILY}" == "openmpi" && "${CONTAINER_CMD}" =~ ^(apptainer|singularity)$ ]]; then
+  log "INFO: Host Open MPI under ${CONTAINER_CMD} often runs ranks in separate user namespaces;"
+  log "INFO: Open MPI's vader BTL will warn about CMA and fall back to memcpy (small perf drop expected)."
+  log "INFO: If you need to avoid it, run with setuid ${CONTAINER_CMD}, share the user namespace, or bind a helpfile path for clearer messaging."
+fi
+
 E4SCL_LAUNCH_ARGS=()
 if [[ -n "${E4S_CL_E4SCL_LAUNCH_ARGS}" ]]; then
   read -r -a E4SCL_LAUNCH_ARGS <<< "${E4S_CL_E4SCL_LAUNCH_ARGS}"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -21,6 +21,15 @@
 
 set -euo pipefail
 
+# ANSI color codes for bold/colored output
+TERM_BOLD_CYAN='\033[1;36m'
+TERM_RESET='\033[0m'
+if [[ ! -t 1 ]]; then
+  # Disable styling if not a TTY
+  TERM_BOLD_CYAN=""
+  TERM_RESET=""
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
@@ -42,7 +51,6 @@ E4S_CL_REBUILD_IMAGE="0"
 E4S_CL_APPTAINER_BUILD_ARGS=""
 E4S_CL_RUN_HOST_BASELINE="1"
 E4S_CL_RUN_CONTAINER_BASELINE="1"
-E4S_CL_PRUNE_INTEL_OPENCL="0"
 E4S_CL_SKIP_PROFILE_DETECT="0"
 E4S_CL_WI4MPI_CFLAGS="-Wno-error=implicit-function-declaration -Wno-error=incompatible-pointer-types -Wno-error=format -Wno-error=int-conversion -Wno-error=return-type -include string.h -include sys/time.h"
 E4S_CL_APPTAINER_EXEC_OPTIONS=""
@@ -55,9 +63,42 @@ E4S_CL_E4SCL_LAUNCH_ARGS=""
 E4S_CL_LAUNCHER_ARGS=""
 E4S_CL_OSU_ARGS=""
 E4S_CL_TIMEOUT_DURATION="60s"
+E4S_CL_VERBOSE="0"
 
 log() { printf "[e4s-cl-test] %s\n" "$*"; }
 fail() { printf "[e4s-cl-test] ERROR: %s\n" "$*" >&2; exit 1; }
+
+print_cmd() {
+  printf "${TERM_BOLD_CYAN}$ %s${TERM_RESET}\n" "$*"
+}
+
+run() {
+  print_cmd "$@"
+  "$@"
+}
+
+run_silent() {
+  local cmd=("$@")
+  print_cmd "${cmd[@]}"
+  if [[ "${E4S_CL_VERBOSE}" == "1" ]]; then
+    "${cmd[@]}"
+  else
+    local log_file
+    log_file=$(mktemp)
+    set +e
+    "${cmd[@]}" > "${log_file}" 2>&1
+    local ret=$?
+    set -e
+    if [[ $ret -ne 0 ]]; then
+      log "Command failed (showing last 20 lines of output):"
+      log "Full log: ${log_file}"
+      tail -n 20 "${log_file}"
+      # rm -f "${log_file}" # Keep log file for debugging on failure
+      return $ret
+    fi
+    rm -f "${log_file}"
+  fi
+}
 
 verify_checksum() {
   local filepath="$1"
@@ -132,7 +173,6 @@ Options:
   --clean-workdir              Delete workdir on exit (default: off)
   --host-baseline <on|off>     Run host-only baseline (default: on)
   --container-baseline <on|off> Run container-only baseline (default: on)
-  --no-prune-intel-opencl      Disable workaround that prunes Intel/OpenCL libs from profile (default: pruning enabled)
   --skip-profile-detect        Skip profile detect if profile already has bindings (default: off)
   --wi4mpi-cflags "..."         Extra C/C++ flags for Wi4MPI build (default: relax GCC 14 errors)
   --apptainer-exec-options "..." Extra apptainer exec options (default: none)
@@ -145,6 +185,7 @@ Options:
   --osu-args "..."             Override OSU benchmark arguments (e.g. "-i 1000 -m 1024:1048576")
                                Safe for latency, bw, and allreduce.
   --timeout <duration>         Timeout for MPI runs (default: 60s)
+  --verbose                    Show build output (default: off, only errors shown)
   --check                      Check environment prerequisites and exit
   -h, --help                   Show help
 
@@ -213,7 +254,6 @@ while [[ $# -gt 0 ]]; do
     --clean-workdir) E4S_CL_KEEP_WORKDIR="0"; shift ;;
     --host-baseline) E4S_CL_RUN_HOST_BASELINE="$(parse_bool "$2")"; shift 2 ;;
     --container-baseline) E4S_CL_RUN_CONTAINER_BASELINE="$(parse_bool "$2")"; shift 2 ;;
-    --no-prune-intel-opencl) E4S_CL_PRUNE_INTEL_OPENCL="0"; shift ;;
     --skip-profile-detect) E4S_CL_SKIP_PROFILE_DETECT="1"; shift ;;
     --wi4mpi-cflags) E4S_CL_WI4MPI_CFLAGS="$2"; shift 2 ;;
     --apptainer-exec-options) E4S_CL_APPTAINER_EXEC_OPTIONS="$2"; shift 2 ;;
@@ -230,6 +270,7 @@ while [[ $# -gt 0 ]]; do
     --launcher-args) E4S_CL_LAUNCHER_ARGS="$2"; shift 2 ;;
     --osu-args) E4S_CL_OSU_ARGS="$2"; shift 2 ;;
     --timeout) E4S_CL_TIMEOUT_DURATION="$2"; shift 2 ;;
+    --verbose) E4S_CL_VERBOSE="1"; shift ;;
     --check) E4S_CL_ONLY_CHECK="1"; shift ;;
     -h|--help) usage; exit 0 ;;
     *) fail "Unknown argument: $1 (use --help)" ;;
@@ -340,7 +381,7 @@ run_timed() {
   local out_file="${E4S_CL_WORKDIR}/timing.dat"
 
   log "Running [${label}]..."
-  log "Command: ${cmd[*]}"
+  print_cmd "${cmd[@]}"
   # Use python for distinct wall-clock measurement
   local start
   start=$(python3 -c 'import time; print(time.time())')
@@ -403,6 +444,227 @@ else
   fail "Neither apptainer nor singularity found. Install one and try again."
 fi
 
+
+# Host MPI detection
+HOST_MPICC="${E4S_CL_HOST_MPI:-$(command -v mpicc || true)}"
+HOST_MPICXX="${E4S_CL_HOST_MPICXX:-$(command -v mpicxx || command -v mpic++ || true)}"
+HOST_MPIRUN="${E4S_CL_HOST_MPIRUN:-$(command -v mpirun || command -v mpiexec || true)}"
+[[ -n "${HOST_MPICC}" ]] || fail "Host MPI compiler not found (mpicc)"
+[[ -n "${HOST_MPIRUN}" ]] || fail "Host MPI launcher not found (mpirun or mpiexec)"
+
+log "Container Runtime: $CONTAINER_CMD"
+log "Host MPI compiler: ${HOST_MPICC}" "$("${HOST_MPICC}" --version | head -n 1 || true)"
+log "Host MPI launcher: ${HOST_MPIRUN}" "$("${HOST_MPIRUN}" --version | head -n 1 || true)"
+
+LAUNCHER_BIN="${E4S_CL_LAUNCHER:-}"
+if [[ -z "${LAUNCHER_BIN}" && "${E4S_CL_SCHEDULER}" == "slurm" ]]; then
+  LAUNCHER_BIN="$(command -v srun || true)"
+fi
+if [[ -z "${LAUNCHER_BIN}" ]]; then
+  LAUNCHER_BIN="${HOST_MPIRUN}"
+fi
+
+if [[ "${LAUNCHER_BIN##*/}" == "srun" ]]; then
+  LAUNCHER_ARGS=("-n" "${E4S_CL_MPI_PROCS}")
+else
+  LAUNCHER_ARGS=("-np" "${E4S_CL_MPI_PROCS}")
+fi
+
+if [[ -n "${E4S_CL_LAUNCHER_ARGS}" ]]; then
+  read -r -a EXTRA_LAUNCHER_ARGS <<< "${E4S_CL_LAUNCHER_ARGS}"
+  LAUNCHER_ARGS+=("${EXTRA_LAUNCHER_ARGS[@]}")
+fi
+
+HOST_MPI_VERSION="$(${HOST_MPIRUN} --version 2>/dev/null | head -n 2 || true)"
+HOST_MPI_FAMILY="$(detect_mpi_family "${HOST_MPI_VERSION}")"
+log "Detected host MPI family: ${HOST_MPI_FAMILY:-unknown}"
+
+
+log "Step 1: Setting up e4s-cl. Using a local virtual environment and editable install to ensure the latest code is used."
+
+# Verify Python has required features before creating venv
+if ! python3 -c "import ctypes" 2>/dev/null; then
+  log "ERROR: Python installation at $(command -v python3) is missing the ctypes module"
+  log "ERROR: This is typically caused by Python being compiled without libffi support"
+  log "ERROR: "
+  log "ERROR: To fix this issue:"
+  log "ERROR:   1. If you loaded a Python module: module unload python"
+  log "ERROR:   2. Use system Python (usually /usr/bin/python3)"
+  log "ERROR:   3. Or load a different Python module that has ctypes support"
+  log "ERROR:   4. Verify with: python3 -c 'import ctypes; print(\"OK\")'"
+  fail "Python missing required ctypes module (needs libffi)"
+fi
+
+PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
+if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 7) else 1)"; then
+  log "Python version check passed: ${PYTHON_VERSION}"
+else
+  log "ERROR: Python ${PYTHON_VERSION} is too old (e4s-cl requires Python 3.7+)"
+  log "ERROR: Current Python: $(command -v python3)"
+  log "ERROR: "
+  log "ERROR: To fix this issue:"
+  log "ERROR:   1. Load a newer Python module: module load python/3.9 (or similar)"
+  log "ERROR:   2. Or use a newer system Python if available"
+  log "ERROR:   3. Ensure the Python has ctypes: python3 -c 'import ctypes'"
+  fail "Python version ${PYTHON_VERSION} is too old (need 3.7+)"
+fi
+
+if [[ ! -x "${REPO_ROOT}/.venv/bin/python" ]]; then
+  run python3 -m venv "${REPO_ROOT}/.venv"
+fi
+run "${REPO_ROOT}/.venv/bin/python" -m pip install -U pip
+run "${REPO_ROOT}/.venv/bin/python" -m pip install -e "${REPO_ROOT}"
+
+E4S_CL_BIN="${REPO_ROOT}/.venv/bin/e4s-cl"
+[[ -x "${E4S_CL_BIN}" ]] || fail "e4s-cl not installed in venv"
+
+
+
+if [[ -n "${E4S_CL_APPTAINER_EXEC_OPTIONS}" ]]; then
+  # Useful for complex container setups
+  log "CONFIG: setting E4S_CL_APPTAINER_EXEC_OPTIONS=${E4S_CL_APPTAINER_EXEC_OPTIONS}"
+  export E4S_CL_APPTAINER_EXEC_OPTIONS="${E4S_CL_APPTAINER_EXEC_OPTIONS}"
+fi
+
+if [[ -n "${E4S_CL_CONTAINER_DIR}" ]]; then
+  # Use a specific container directory relative to host environment
+  log "CONFIG: setting E4S_CL_CONTAINER_DIR=${E4S_CL_CONTAINER_DIR}"
+  export E4S_CL_CONTAINER_DIR="${E4S_CL_CONTAINER_DIR}"
+fi
+
+log "Preparing workdir: ${E4S_CL_WORKDIR}"
+mkdir -p "${E4S_CL_WORKDIR}"
+mkdir -p "${E4S_CL_CACHE_DIR}"
+
+log "Fetching OSU benchmarks"
+OSU_TARBALL="${E4S_CL_CACHE_DIR}/osu.tar.gz"
+OSU_SRC_DIR="${E4S_CL_WORKDIR}/osu"
+OSU_META_FILE="${E4S_CL_WORKDIR}/osu.meta"
+OSU_CHECKSUM_FILE="${E4S_CL_CACHE_DIR}/osu.sha256"
+
+NEED_DOWNLOAD="0"
+if [[ ! -f "${OSU_TARBALL}" || ! -f "${OSU_META_FILE}" ]]; then
+  NEED_DOWNLOAD="1"
+  rm -rf "${OSU_SRC_DIR}"
+elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_META_FILE}"; then
+  NEED_DOWNLOAD="1"
+  rm -rf "${OSU_SRC_DIR}"
+fi
+
+if [[ "${NEED_DOWNLOAD}" == "1" ]]; then
+  log "Downloading OSU benchmarks from: ${E4S_CL_OSU_URL}"
+  run curl -L "${E4S_CL_OSU_URL}" -o "${OSU_TARBALL}"
+  
+  # Verify checksum unless explicitly skipped
+  if [[ "${E4S_CL_OSU_CHECKSUM_REQUIRED}" == "1" ]]; then
+    if [[ -z "${E4S_CL_OSU_SHA256}" ]]; then
+      fail "OSU checksum verification enabled but no hash provided. Use --osu-sha256 or --osu-skip-checksum"
+    fi
+    log "Verifying OSU benchmarks integrity (SHA256)..."
+    verify_checksum "${OSU_TARBALL}" "${E4S_CL_OSU_SHA256}" "sha256"
+    printf "%s\n" "${E4S_CL_OSU_SHA256}" > "${OSU_CHECKSUM_FILE}"
+  else
+    log "WARNING: Skipping OSU checksum verification. Ensure you trust the source at ${E4S_CL_OSU_URL}"
+    printf "%s  (unverified)\n" "manual-skip" > "${OSU_CHECKSUM_FILE}"
+  fi
+else
+  # Already downloaded; verify cached version matches current expectations if verification is enabled
+  if [[ "${E4S_CL_OSU_CHECKSUM_REQUIRED}" == "1" && -n "${E4S_CL_OSU_SHA256}" ]]; then
+    if [[ -f "${OSU_CHECKSUM_FILE}" ]] && grep -Fq "${E4S_CL_OSU_SHA256}" "${OSU_CHECKSUM_FILE}" 2>/dev/null; then
+      log "Cached OSU benchmarks already verified"
+    else
+      log "Verifying cached OSU benchmarks integrity (SHA256)..."
+      verify_checksum "${OSU_TARBALL}" "${E4S_CL_OSU_SHA256}" "sha256"
+      printf "%s\n" "${E4S_CL_OSU_SHA256}" > "${OSU_CHECKSUM_FILE}"
+    fi
+  fi
+fi
+
+if [[ ! -d "${OSU_SRC_DIR}" ]]; then
+  mkdir -p "${OSU_SRC_DIR}"
+  run tar -xzf "${OSU_TARBALL}" -C "${OSU_SRC_DIR}" --strip-components=1
+fi
+printf "osu_url=%s\nosu_sha256=%s\n" "${E4S_CL_OSU_URL}" "${E4S_CL_OSU_SHA256}" > "${OSU_META_FILE}"
+
+if [[ "${E4S_CL_MODE}" == "light" ]]; then
+  OSU_BENCHES=("pt2pt/osu_latency")
+  OSU_ARGS=("-x" "100" "-i" "1000" "-m" "8:8")
+else
+  OSU_BENCHES=("pt2pt/osu_latency" "pt2pt/osu_bw" "collective/osu_allreduce")
+  OSU_ARGS=()
+fi
+
+if [[ -n "${E4S_CL_OSU_ARGS}" ]]; then
+  read -r -a OSU_ARGS <<< "${E4S_CL_OSU_ARGS}"
+else
+  # Default Arguments:
+  # - Latency: 1000 iterations to dampen startup noise
+  # - Bandwidth: up to 1MB (1048576) is usually sufficient to see peak BW without timing out
+  OSU_ARGS=("-x" "100" "-i" "1000" "-m" "8:32768")
+fi
+
+if [[ "${E4S_CL_MPI_PROCS}" != "2" ]]; then
+  if printf '%s\n' "${OSU_BENCHES[@]}" | grep -q "pt2pt/osu_"; then
+    log "NOTE: pt2pt OSU benchmarks require exactly 2 processes (current: ${E4S_CL_MPI_PROCS})"
+  fi
+fi
+
+log "Step 2: Building Host Benchmarks. We compile OSU benchmarks on the host to 1) check host MPI health, 2) set a performance baseline, and 3) provide a binary for e4s-cl to analyze."
+OSU_HOST_PREFIX="${E4S_CL_WORKDIR}/osu-host"
+OSU_HOST_META="${OSU_HOST_PREFIX}/.build-meta"
+HOST_MPICC_VERSION="$(${HOST_MPICC} --version | head -n 1 || true)"
+REBUILD_HOST_OSU="0"
+if [[ ! -d "${OSU_HOST_PREFIX}" || ! -f "${OSU_HOST_META}" ]]; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "mpicc=${HOST_MPICC}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "mpicc_version=${HOST_MPICC_VERSION}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+fi
+
+if [[ "${REBUILD_HOST_OSU}" == "1" ]]; then
+  log "(Re)building host OSU benchmarks"
+  rm -rf "${OSU_HOST_PREFIX}"
+  mkdir -p "${OSU_HOST_PREFIX}"
+  (
+    # Clear CFLAGS/CXXFLAGS to avoid injecting incompatible compiler flags
+    unset CFLAGS
+    unset CXXFLAGS
+    cd "${OSU_SRC_DIR}"
+
+    build_cmd() {
+      # Configure with both CC and CXX set to MPI wrappers to avoid linker issues
+      if [[ -n "${HOST_MPICXX}" ]]; then
+        ./configure CC="${HOST_MPICC}" CXX="${HOST_MPICXX}" --prefix="${OSU_HOST_PREFIX}"
+      else
+        # If no MPI C++ wrapper found, unset CXX to prevent using raw compiler for linking
+        unset CXX
+        ./configure CC="${HOST_MPICC}" --prefix="${OSU_HOST_PREFIX}"
+      fi
+      make -j
+      make install
+    }
+    
+    run_silent build_cmd
+  )
+  printf "mpicc=%s\nmpicc_version=%s\nosu_url=%s\n" "${HOST_MPICC}" "${HOST_MPICC_VERSION}" "${E4S_CL_OSU_URL}" > "${OSU_HOST_META}"
+else
+  log "Reusing host OSU benchmarks: ${OSU_HOST_PREFIX}"
+fi
+
+if [[ "${E4S_CL_RUN_HOST_BASELINE}" == "1" ]]; then
+  log "Step 2b: Running baseline host MPI benchmarks. This confirms the host MPI works and provides reference numbers."
+  for bench in "${OSU_BENCHES[@]}"; do
+    bench_name="$(basename "${bench}")"
+    out_file="${E4S_CL_WORKDIR}/host_${bench_name}.txt"
+    run_timed "host_${bench_name}" "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" \
+      "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/${bench}" \
+      "${OSU_ARGS[@]}" | tee "${out_file}"
+  done
+fi
+
 if [[ "${E4S_CL_BUILD_IMAGE}" == "1" ]]; then
   mkdir -p "${E4S_CL_CACHE_DIR}"
   if [[ -z "${E4S_CL_IMAGE}" ]]; then
@@ -445,7 +707,7 @@ EOF
     if [[ -z "${E4S_CL_APPTAINER_BUILD_ARGS}" ]]; then
       E4S_CL_APPTAINER_BUILD_ARGS="--fakeroot"
     fi
-    ${CONTAINER_CMD} build ${E4S_CL_APPTAINER_BUILD_ARGS} "${E4S_CL_IMAGE}" "${E4S_CL_IMAGE_DEF}"
+    run_silent ${CONTAINER_CMD} build ${E4S_CL_APPTAINER_BUILD_ARGS} "${E4S_CL_IMAGE}" "${E4S_CL_IMAGE_DEF}"
   fi
 fi
 
@@ -454,51 +716,15 @@ if [[ "${E4S_CL_IMAGE}" != docker://* && "${E4S_CL_IMAGE}" != library://* ]]; th
   [[ -f "${E4S_CL_IMAGE}" ]] || fail "E4S_CL_IMAGE not found: ${E4S_CL_IMAGE}"
 fi
 
-# Host MPI detection
-HOST_MPICC="${E4S_CL_HOST_MPI:-$(command -v mpicc || true)}"
-HOST_MPICXX="${E4S_CL_HOST_MPICXX:-$(command -v mpicxx || command -v mpic++ || true)}"
-HOST_MPIRUN="${E4S_CL_HOST_MPIRUN:-$(command -v mpirun || command -v mpiexec || true)}"
-[[ -n "${HOST_MPICC}" ]] || fail "Host MPI compiler not found (mpicc)"
-[[ -n "${HOST_MPIRUN}" ]] || fail "Host MPI launcher not found (mpirun or mpiexec)"
-
-log "Container Runtime: $CONTAINER_CMD"
-log "Host MPI compiler: ${HOST_MPICC}" "$("${HOST_MPICC}" --version | head -n 1 || true)"
-log "Host MPI launcher: ${HOST_MPIRUN}" "$("${HOST_MPIRUN}" --version | head -n 1 || true)"
-
-LAUNCHER_BIN="${E4S_CL_LAUNCHER:-}"
-if [[ -z "${LAUNCHER_BIN}" && "${E4S_CL_SCHEDULER}" == "slurm" ]]; then
-  LAUNCHER_BIN="$(command -v srun || true)"
-fi
-if [[ -z "${LAUNCHER_BIN}" ]]; then
-  LAUNCHER_BIN="${HOST_MPIRUN}"
-fi
-
-if [[ "${LAUNCHER_BIN##*/}" == "srun" ]]; then
-  LAUNCHER_ARGS=("-n" "${E4S_CL_MPI_PROCS}")
-else
-  LAUNCHER_ARGS=("-np" "${E4S_CL_MPI_PROCS}")
-fi
-
-if [[ -n "${E4S_CL_LAUNCHER_ARGS}" ]]; then
-  read -r -a EXTRA_LAUNCHER_ARGS <<< "${E4S_CL_LAUNCHER_ARGS}"
-  LAUNCHER_ARGS+=("${EXTRA_LAUNCHER_ARGS[@]}")
-fi
-
-HOST_MPI_VERSION="$(${HOST_MPIRUN} --version 2>/dev/null | head -n 2 || true)"
-HOST_MPI_FAMILY="$(detect_mpi_family "${HOST_MPI_VERSION}")"
 CONTAINER_MPI_VERSION="$(${CONTAINER_CMD} exec "${E4S_CL_IMAGE}" mpirun --version 2>/dev/null | head -n 2 || true)"
 if [[ -z "$(detect_mpi_family "${CONTAINER_MPI_VERSION}")" ]]; then
   CONTAINER_MPI_VERSION+=$'\n'"$(${CONTAINER_CMD} exec "${E4S_CL_IMAGE}" mpichversion 2>/dev/null | head -n 2 || true)"
 fi
 CONTAINER_MPI_FAMILY="$(detect_mpi_family "${CONTAINER_MPI_VERSION}")"
 
-log "Detected host MPI family: ${HOST_MPI_FAMILY:-unknown}"
 log "Detected container MPI family: ${CONTAINER_MPI_FAMILY:-unknown}"
 
-# Best-effort heads-up for the Open MPI CMA user-namespace warning that shows up
-# when the host MPI is Open MPI and we run ranks inside an apptainer/singularity
-# user namespace (non-setuid). In that case the `vader` BTL drops to memcpy and
-# emits a cma-different-user-namespace warning; bandwidth/latency dip is normal.
+# Best-effort heads-up for the Open MPI CMA user-namespace warning
 if [[ "${HOST_MPI_FAMILY}" == "openmpi" && "${CONTAINER_CMD}" =~ ^(apptainer|singularity)$ ]]; then
   log "INFO: Host Open MPI under ${CONTAINER_CMD} often runs ranks in separate user namespaces;"
   log "INFO: Open MPI's vader BTL will warn about CMA and fall back to memcpy (small perf drop expected)."
@@ -520,44 +746,6 @@ elif [[ -n "${HOST_MPI_FAMILY}" && -n "${CONTAINER_MPI_FAMILY}" && "${HOST_MPI_F
   doc_todo "e4s-cl requires explicit --from when container MPI differs; add guidance to auto-detect and pass --from."
 fi
 
-log "Step 1: Setting up e4s-cl. Using a local virtual environment and editable install to ensure the latest code is used."
-
-# Verify Python has required features before creating venv
-if ! python3 -c "import ctypes" 2>/dev/null; then
-  log "ERROR: Python installation at $(command -v python3) is missing the ctypes module"
-  log "ERROR: This is typically caused by Python being compiled without libffi support"
-  log "ERROR: "
-  log "ERROR: To fix this issue:"
-  log "ERROR:   1. If you loaded a Python module: module unload python"
-  log "ERROR:   2. Use system Python (usually /usr/bin/python3)"
-  log "ERROR:   3. Or load a different Python module that has ctypes support"
-  log "ERROR:   4. Verify with: python3 -c 'import ctypes; print(\"OK\")'"
-  fail "Python missing required ctypes module (needs libffi)"
-fi
-
-PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
-if python3 -c "import sys; sys.exit(0 if sys.version_info >= (3, 7) else 1)"; then
-  log "Python version check passed: ${PYTHON_VERSION}"
-else
-  log "ERROR: Python ${PYTHON_VERSION} is too old (e4s-cl requires Python 3.7+)"
-  log "ERROR: Current Python: $(command -v python3)"
-  log "ERROR: "
-  log "ERROR: To fix this issue:"
-  log "ERROR:   1. Load a newer Python module: module load python/3.9 (or similar)"
-  log "ERROR:   2. Or use a newer system Python if available"
-  log "ERROR:   3. Ensure the Python has ctypes: python3 -c 'import ctypes'"
-  fail "Python version ${PYTHON_VERSION} is too old (need 3.7+)"
-fi
-
-if [[ ! -x "${REPO_ROOT}/.venv/bin/python" ]]; then
-  python3 -m venv "${REPO_ROOT}/.venv"
-fi
-"${REPO_ROOT}/.venv/bin/python" -m pip install -U pip
-"${REPO_ROOT}/.venv/bin/python" -m pip install -e "${REPO_ROOT}"
-
-E4S_CL_BIN="${REPO_ROOT}/.venv/bin/e4s-cl"
-[[ -x "${E4S_CL_BIN}" ]] || fail "e4s-cl not installed in venv"
-
 if [[ "${NEEDS_TRANSLATION}" == "1" ]]; then
   log "Wi4MPI translation required; e4s-cl will install Wi4MPI during launch if missing"
 
@@ -575,153 +763,12 @@ if [[ "${NEEDS_TRANSLATION}" == "1" ]]; then
   fi
 fi
 
-if [[ -n "${E4S_CL_APPTAINER_EXEC_OPTIONS}" ]]; then
-  # Useful for complex container setups
-  log "CONFIG: setting E4S_CL_APPTAINER_EXEC_OPTIONS=${E4S_CL_APPTAINER_EXEC_OPTIONS}"
-  export E4S_CL_APPTAINER_EXEC_OPTIONS="${E4S_CL_APPTAINER_EXEC_OPTIONS}"
-fi
-
-if [[ -n "${E4S_CL_CONTAINER_DIR}" ]]; then
-  # Use a specific container directory relative to host environment
-  log "CONFIG: setting E4S_CL_CONTAINER_DIR=${E4S_CL_CONTAINER_DIR}"
-  export E4S_CL_CONTAINER_DIR="${E4S_CL_CONTAINER_DIR}"
-fi
-
-log "Preparing workdir: ${E4S_CL_WORKDIR}"
-mkdir -p "${E4S_CL_WORKDIR}"
-mkdir -p "${E4S_CL_CACHE_DIR}"
-
-log "Fetching OSU benchmarks"
-OSU_TARBALL="${E4S_CL_CACHE_DIR}/osu.tar.gz"
-OSU_SRC_DIR="${E4S_CL_WORKDIR}/osu"
-OSU_META_FILE="${E4S_CL_WORKDIR}/osu.meta"
-OSU_CHECKSUM_FILE="${E4S_CL_CACHE_DIR}/osu.sha256"
-
-NEED_DOWNLOAD="0"
-if [[ ! -f "${OSU_TARBALL}" || ! -f "${OSU_META_FILE}" ]]; then
-  NEED_DOWNLOAD="1"
-  rm -rf "${OSU_SRC_DIR}"
-elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_META_FILE}"; then
-  NEED_DOWNLOAD="1"
-  rm -rf "${OSU_SRC_DIR}"
-fi
-
-if [[ "${NEED_DOWNLOAD}" == "1" ]]; then
-  log "Downloading OSU benchmarks from: ${E4S_CL_OSU_URL}"
-  curl -L "${E4S_CL_OSU_URL}" -o "${OSU_TARBALL}"
-  
-  # Verify checksum unless explicitly skipped
-  if [[ "${E4S_CL_OSU_CHECKSUM_REQUIRED}" == "1" ]]; then
-    if [[ -z "${E4S_CL_OSU_SHA256}" ]]; then
-      fail "OSU checksum verification enabled but no hash provided. Use --osu-sha256 or --osu-skip-checksum"
-    fi
-    log "Verifying OSU benchmarks integrity (SHA256)..."
-    verify_checksum "${OSU_TARBALL}" "${E4S_CL_OSU_SHA256}" "sha256"
-    printf "%s\n" "${E4S_CL_OSU_SHA256}" > "${OSU_CHECKSUM_FILE}"
-  else
-    log "WARNING: Skipping OSU checksum verification. Ensure you trust the source at ${E4S_CL_OSU_URL}"
-    printf "%s  (unverified)\n" "manual-skip" > "${OSU_CHECKSUM_FILE}"
-  fi
-else
-  # Already downloaded; verify cached version matches current expectations if verification is enabled
-  if [[ "${E4S_CL_OSU_CHECKSUM_REQUIRED}" == "1" && -n "${E4S_CL_OSU_SHA256}" ]]; then
-    if [[ -f "${OSU_CHECKSUM_FILE}" ]] && grep -Fq "${E4S_CL_OSU_SHA256}" "${OSU_CHECKSUM_FILE}" 2>/dev/null; then
-      log "Cached OSU benchmarks already verified"
-    else
-      log "Verifying cached OSU benchmarks integrity (SHA256)..."
-      verify_checksum "${OSU_TARBALL}" "${E4S_CL_OSU_SHA256}" "sha256"
-      printf "%s\n" "${E4S_CL_OSU_SHA256}" > "${OSU_CHECKSUM_FILE}"
-    fi
-  fi
-fi
-
-if [[ ! -d "${OSU_SRC_DIR}" ]]; then
-  mkdir -p "${OSU_SRC_DIR}"
-  tar -xzf "${OSU_TARBALL}" -C "${OSU_SRC_DIR}" --strip-components=1
-fi
-printf "osu_url=%s\nosu_sha256=%s\n" "${E4S_CL_OSU_URL}" "${E4S_CL_OSU_SHA256}" > "${OSU_META_FILE}"
-
-if [[ "${E4S_CL_MODE}" == "light" ]]; then
-  OSU_BENCHES=("pt2pt/osu_latency" "pt2pt/osu_bw")
-  OSU_ARGS=("-x" "100" "-i" "1000" "-m" "8:65536")
-else
-  OSU_BENCHES=("pt2pt/osu_latency" "pt2pt/osu_bw" "collective/osu_allreduce")
-  OSU_ARGS=()
-fi
-
-if [[ -n "${E4S_CL_OSU_ARGS}" ]]; then
-  read -r -a OSU_ARGS <<< "${E4S_CL_OSU_ARGS}"
-else
-  # Default Arguments:
-  # - Latency: 1000 iterations to dampen startup noise
-  # - Bandwidth: up to 1MB (1048576) is usually sufficient to see peak BW without timing out
-  OSU_ARGS=("-x" "100" "-i" "1000" "-m" "8:1048576")
-fi
-
-if [[ "${E4S_CL_MPI_PROCS}" != "2" ]]; then
-  if printf '%s\n' "${OSU_BENCHES[@]}" | grep -q "pt2pt/osu_"; then
-    log "NOTE: pt2pt OSU benchmarks require exactly 2 processes (current: ${E4S_CL_MPI_PROCS})"
-  fi
-fi
-
-log "Step 2: Building Host Benchmarks. We compile OSU benchmarks on the host to 1) check host MPI health, 2) set a performance baseline, and 3) provide a binary for e4s-cl to analyze."
-OSU_HOST_PREFIX="${E4S_CL_WORKDIR}/osu-host"
-OSU_HOST_META="${OSU_HOST_PREFIX}/.build-meta"
-HOST_MPICC_VERSION="$(${HOST_MPICC} --version | head -n 1 || true)"
-REBUILD_HOST_OSU="0"
-if [[ ! -d "${OSU_HOST_PREFIX}" || ! -f "${OSU_HOST_META}" ]]; then
-  REBUILD_HOST_OSU="1"
-elif ! grep -Fq "mpicc=${HOST_MPICC}" "${OSU_HOST_META}"; then
-  REBUILD_HOST_OSU="1"
-elif ! grep -Fq "mpicc_version=${HOST_MPICC_VERSION}" "${OSU_HOST_META}"; then
-  REBUILD_HOST_OSU="1"
-elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_HOST_META}"; then
-  REBUILD_HOST_OSU="1"
-fi
-
-if [[ "${REBUILD_HOST_OSU}" == "1" ]]; then
-  log "(Re)building host OSU benchmarks"
-  rm -rf "${OSU_HOST_PREFIX}"
-  mkdir -p "${OSU_HOST_PREFIX}"
-  (
-    # Clear CFLAGS/CXXFLAGS to avoid injecting incompatible compiler flags
-    # (e.g., GCC-specific flags when using NVIDIA HPC or other compilers)
-    unset CFLAGS
-    unset CXXFLAGS
-    cd "${OSU_SRC_DIR}"
-    # Configure with both CC and CXX set to MPI wrappers to avoid linker issues
-    if [[ -n "${HOST_MPICXX}" ]]; then
-      ./configure CC="${HOST_MPICC}" CXX="${HOST_MPICXX}" --prefix="${OSU_HOST_PREFIX}"
-    else
-      # If no MPI C++ wrapper found, unset CXX to prevent using raw compiler for linking
-      unset CXX
-      ./configure CC="${HOST_MPICC}" --prefix="${OSU_HOST_PREFIX}"
-    fi
-    make -j
-    make install
-  )
-  printf "mpicc=%s\nmpicc_version=%s\nosu_url=%s\n" "${HOST_MPICC}" "${HOST_MPICC_VERSION}" "${E4S_CL_OSU_URL}" > "${OSU_HOST_META}"
-else
-  log "Reusing host OSU benchmarks: ${OSU_HOST_PREFIX}"
-fi
-
-if [[ "${E4S_CL_RUN_HOST_BASELINE}" == "1" ]]; then
-  log "Step 2b: Running baseline host MPI benchmarks. This confirms the host MPI works and provides reference numbers."
-  for bench in "${OSU_BENCHES[@]}"; do
-    bench_name="$(basename "${bench}")"
-    out_file="${E4S_CL_WORKDIR}/host_${bench_name}.txt"
-    run_timed "host_${bench_name}" "${LAUNCHER_BIN}" "${LAUNCHER_ARGS[@]}" \
-      "${OSU_HOST_PREFIX}/libexec/osu-micro-benchmarks/mpi/${bench}" \
-      "${OSU_ARGS[@]}" | tee "${out_file}"
-  done
-fi
-
 log "Step 3: Configuring e4s-cl Profile. A 'profile' stores metadata about the container backend, image, and the host libraries we want to inject."
-if ! "${E4S_CL_BIN}" profile create "${E4S_CL_PROFILE_NAME}" --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"; then
+if ! run "${E4S_CL_BIN}" profile create "${E4S_CL_PROFILE_NAME}" --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"; then
   log "Profile exists, updating image/backend"
-  "${E4S_CL_BIN}" profile edit --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"
+  run "${E4S_CL_BIN}" profile edit --backend "${CONTAINER_CMD}" --image "${E4S_CL_IMAGE}"
 fi
-"${E4S_CL_BIN}" profile select "${E4S_CL_PROFILE_NAME}"
+run "${E4S_CL_BIN}" profile select "${E4S_CL_PROFILE_NAME}"
 
 # Validate detection results; if empty, retry once and fail early with guidance.
 # This mirrors how a user would re-run detection when the profile isn't populated.
@@ -758,7 +805,7 @@ if ! profile_has_bindings; then
 fi
 
 log "Profile Content (Libraries/Files to be bound):"
-"${E4S_CL_BIN}" profile show
+run "${E4S_CL_BIN}" profile show
 
 log "Step 5: Building Container Benchmarks. We compile the same benchmarks *inside* the container against the Container's MPI to demonstrate ABI compatibility or translation."
 OSU_CONT_PREFIX="${E4S_CL_WORKDIR}/osu-container"
@@ -776,7 +823,7 @@ if [[ "${REBUILD_CONT_OSU}" == "1" ]]; then
   log "(Re)building container OSU benchmarks"
   rm -rf "${OSU_CONT_PREFIX}"
   mkdir -p "${OSU_CONT_PREFIX}"
-  ${CONTAINER_CMD} exec -B "${E4S_CL_WORKDIR}:/work" -B "${E4S_CL_CACHE_DIR}:/cache" "${E4S_CL_IMAGE}" bash -lc "\
+  run_silent ${CONTAINER_CMD} exec -B "${E4S_CL_WORKDIR}:/work" -B "${E4S_CL_CACHE_DIR}:/cache" "${E4S_CL_IMAGE}" bash -lc "\
     set -euo pipefail; \
     unset CFLAGS; \
     unset CXXFLAGS; \
@@ -796,7 +843,10 @@ fi
 
 log "Step 6: MAIN TEST. Running the container-compiled binary using the Host's MPI. e4s-cl handles the library injection and launcher wrapping."
 log "Debug: Verifying library resolution inside container (ldd)"
-"${E4S_CL_BIN}" launch "${E4SCL_LAUNCH_ARGS[@]}" "${LAUNCHER_BIN}" -n 1 ldd "${OSU_CONT_PREFIX}/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency" | grep -E "libmpi|libmpich|libpami|libfabric" || echo "  (ldd check finished, no obvious MPI libs found in grep filter)"
+# run is used here to show the command, but output is piped to grep, so only if it fails (not matching libmpi) will echo print.
+# But grep consumes stdout. The original logic was: run ldd | grep ... || echo ...
+# If I use 'run' it will print the command.
+run "${E4S_CL_BIN}" launch "${E4SCL_LAUNCH_ARGS[@]}" "${LAUNCHER_BIN}" -n 1 ldd "${OSU_CONT_PREFIX}/libexec/osu-micro-benchmarks/mpi/pt2pt/osu_latency" | grep -E "libmpi|libmpich|libpami|libfabric" || echo "  (ldd check finished, no obvious MPI libs found in grep filter)"
 
 for bench in "${OSU_BENCHES[@]}"; do
   bench_name="$(basename "${bench}")"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -823,7 +823,7 @@ if [[ "${REBUILD_CONT_OSU}" == "1" ]]; then
   log "(Re)building container OSU benchmarks"
   rm -rf "${OSU_CONT_PREFIX}"
   mkdir -p "${OSU_CONT_PREFIX}"
-  run_silent ${CONTAINER_CMD} exec -B "${E4S_CL_WORKDIR}:/work" -B "${E4S_CL_CACHE_DIR}:/cache" "${E4S_CL_IMAGE}" bash -lc "\
+  run_silent "${CONTAINER_CMD}" exec -B "${E4S_CL_WORKDIR}:/work" -B "${E4S_CL_CACHE_DIR}:/cache" "${E4S_CL_IMAGE}" bash -lc "\
     set -euo pipefail; \
     unset CFLAGS; \
     unset CXXFLAGS; \

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -387,10 +387,8 @@ HOST_MPIRUN="${E4S_CL_HOST_MPIRUN:-$(command -v mpirun || command -v mpiexec || 
 [[ -n "${HOST_MPIRUN}" ]] || fail "Host MPI launcher not found (mpirun or mpiexec)"
 
 log "Container Runtime: $CONTAINER_CMD"
-log "Host MPI compiler: ${HOST_MPICC}"\
-"$("${HOST_MPICC}" --version | head -n 1 || true)"
-log "Host MPI launcher: ${HOST_MPIRUN}"\
-"$("${HOST_MPIRUN}" --version | head -n 1 || true)"
+log "Host MPI compiler: ${HOST_MPICC}" "$("${HOST_MPICC}" --version | head -n 1 || true)"
+log "Host MPI launcher: ${HOST_MPIRUN}" "$("${HOST_MPIRUN}" --version | head -n 1 || true)"
 
 LAUNCHER_BIN="${E4S_CL_LAUNCHER:-}"
 if [[ -z "${LAUNCHER_BIN}" && "${E4S_CL_SCHEDULER}" == "slurm" ]]; then

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -64,6 +64,7 @@ E4S_CL_LAUNCHER_ARGS=""
 E4S_CL_OSU_ARGS=""
 E4S_CL_TIMEOUT_DURATION="60s"
 E4S_CL_VERBOSE="0"
+E4S_CL_SKIP_PMI_CHECK="0"
 
 log() { printf "[e4s-cl-test] %s\n" "$*"; }
 fail() { printf "[e4s-cl-test] ERROR: %s\n" "$*" >&2; exit 1; }
@@ -179,9 +180,10 @@ Options:
   --container-dir <path>       Container data dir (default: /tmp/.e4s-cl)
   --host-mpicc <path>          Override host mpicc (default: auto-detect)
   --host-mpirun <path>         Override host mpirun/mpiexec (default: auto-detect)
-  --launcher <cmd>             Force launcher (mpirun or srun) (default: auto-detect)
+  --launcher <cmd>             Force launcher (mpirun or srun path) (default: auto-detect)
   --scheduler <name>           If "slurm", use srun when available (default: none)
   --launcher-args "..."        Extra arguments for the MPI launcher (e.g. -p partition -N 2)
+  --skip-pmi-check             Skip PMI connectivity sanity check (default: off)
   --osu-args "..."             Override OSU benchmark arguments (e.g. "-i 1000 -m 1024:1048576")
                                Safe for latency, bw, and allreduce.
   --timeout <duration>         Timeout for MPI runs (default: 60s)
@@ -266,6 +268,7 @@ while [[ $# -gt 0 ]]; do
     --host-mpirun) E4S_CL_HOST_MPIRUN="$2"; shift 2 ;;
     --launcher) E4S_CL_LAUNCHER="$2"; shift 2 ;;
     --scheduler) E4S_CL_SCHEDULER="$2"; shift 2 ;;
+    --skip-pmi-check) E4S_CL_SKIP_PMI_CHECK="1"; shift ;;
     --e4scl-launch-args) E4S_CL_E4SCL_LAUNCH_ARGS="$2"; shift 2 ;;
     --launcher-args) E4S_CL_LAUNCHER_ARGS="$2"; shift 2 ;;
     --osu-args) E4S_CL_OSU_ARGS="$2"; shift 2 ;;
@@ -336,8 +339,12 @@ if [[ "${E4S_CL_ONLY_CHECK:-0}" == "1" ]]; then
   
   if check_cmd mpirun; then
      log "  Found: $(command -v mpirun)"
+  elif check_cmd mpiexec; then
+     log "  Found: $(command -v mpiexec)"
+  elif check_cmd srun; then
+     log "  mpirun/mpiexec not found, but srun is available (use --launcher srun or --scheduler slurm)"
   else
-     log "  MISSING: mpirun"
+     log "  MISSING: mpirun/mpiexec (and no srun available)"
      MISSING=1
   fi
   
@@ -350,6 +357,85 @@ if [[ "${E4S_CL_ONLY_CHECK:-0}" == "1" ]]; then
        MISSING=1
     fi
   done
+
+  log "Checking Slurm/PMI..."
+  if check_cmd srun; then
+    SRUN_PATH="$(command -v srun)"
+    SRUN_VER="$(srun --version 2>/dev/null | awk '{print $2}' || true)"
+    log "  Found: srun ${SRUN_VER} (${SRUN_PATH})"
+
+    # Check for srun/slurmd version mismatch — collect per-node info
+    # Build a map of slurmd version → node names for readable output
+    SRUN_MAJOR="$(echo "${SRUN_VER}" | cut -d. -f1-2)"
+    SLURM_MISMATCH=0
+    declare -A VERSION_NODES  # version -> comma-separated node list
+    # Parse scontrol output: extract NodeName and Version from each node block
+    CURRENT_NODE=""
+    while IFS= read -r LINE; do
+      if [[ "${LINE}" =~ NodeName=([^[:space:]]+) ]]; then
+        CURRENT_NODE="${BASH_REMATCH[1]}"
+      fi
+      if [[ -n "${CURRENT_NODE}" && "${LINE}" =~ Version=([^[:space:]]+) ]]; then
+        NODE_VER="${BASH_REMATCH[1]}"
+        if [[ -n "${VERSION_NODES[${NODE_VER}]+x}" ]]; then
+          VERSION_NODES[${NODE_VER}]="${VERSION_NODES[${NODE_VER}]}, ${CURRENT_NODE}"
+        else
+          VERSION_NODES[${NODE_VER}]="${CURRENT_NODE}"
+        fi
+        CURRENT_NODE=""
+      fi
+    done < <(scontrol show node 2>/dev/null || true)
+
+    if [[ ${#VERSION_NODES[@]} -gt 0 ]]; then
+      # Find the single best srun for the most common mismatched version
+      SUGGESTED_SRUN=""
+      SUGGESTED_VER=""
+      for NV in "${!VERSION_NODES[@]}"; do
+        NV_MAJOR="$(echo "${NV}" | cut -d. -f1-2)"
+        if [[ "${SRUN_MAJOR}" != "${NV_MAJOR}" ]]; then
+          SLURM_MISMATCH=1
+          NODES="${VERSION_NODES[${NV}]}"
+          log "  WARNING: slurmd ${NV} on nodes: ${NODES}"
+        fi
+      done
+
+      if [[ "${SLURM_MISMATCH}" == "1" ]]; then
+        log "  WARNING: srun ${SRUN_VER} does not match slurmd on some compute nodes!"
+        log "  WARNING: This causes PMI2 failures. Use --launcher <path-to-matching-srun>"
+        log "  WARNING: Pick the srun version matching the nodes in your target partition."
+
+        # Find compatible srun paths for each mismatched version
+        declare -A SUGGESTED_FOR_MAJOR  # major.minor -> best srun path
+        for NV in "${!VERSION_NODES[@]}"; do
+          NV_MAJOR="$(echo "${NV}" | cut -d. -f1-2)"
+          [[ "${SRUN_MAJOR}" != "${NV_MAJOR}" ]] || continue
+          [[ -z "${SUGGESTED_FOR_MAJOR[${NV_MAJOR}]+x}" ]] || continue
+
+          EXACT="" FALLBACK=""
+          for D in /usr/local/packages/slurm/*/bin/srun; do
+            [[ -x "$D" ]] || continue
+            DV="$("$D" --version 2>/dev/null | awk '{print $2}' || true)"
+            if [[ "${DV}" == "${NV}" ]]; then EXACT="$D"; break; fi
+            DV_MAJOR="$(echo "${DV}" | cut -d. -f1-2)"
+            if [[ "${DV_MAJOR}" == "${NV_MAJOR}" && -z "${FALLBACK}" ]]; then FALLBACK="$D"; fi
+          done
+          BEST="${EXACT:-${FALLBACK}}"
+          if [[ -n "${BEST}" ]]; then
+            BMV="$("${BEST}" --version 2>/dev/null | awk '{print $2}' || true)"
+            SUGGESTED_FOR_MAJOR[${NV_MAJOR}]="${BEST}"
+            log "  SUGGESTION: --launcher ${BEST} (version ${BMV}, for slurmd ${NV_MAJOR}.x nodes)"
+          fi
+        done
+        MISSING=1
+      else
+        log "  srun/slurmd version match: OK"
+      fi
+    else
+      log "  Could not check slurmd versions (scontrol unavailable)"
+    fi
+  else
+    log "  srun not found (not Slurm-managed, or srun not in PATH)"
+  fi
   
   if [[ "$MISSING" -eq 1 ]]; then
      fail "One or more prerequisites missing."
@@ -392,8 +478,10 @@ run_timed() {
   set -e
 
   if [[ $ret -eq 124 ]]; then
+    log "HINT: Run './scripts/demo.sh --check' to diagnose environment issues (e.g. srun/slurmd version mismatch)"
     fail "Command timed out (${E4S_CL_TIMEOUT_DURATION}): ${cmd[*]}"
   elif [[ $ret -ne 0 ]]; then
+    log "HINT: Run './scripts/demo.sh --check' to diagnose environment issues (e.g. srun/slurmd version mismatch)"
     fail "Command failed (exit $ret): ${cmd[*]}"
   fi
 
@@ -424,6 +512,156 @@ detect_mpi_family() {
     echo "mpich"
   else
     echo ""
+  fi
+}
+
+# Compute environment fingerprint for build cache invalidation.
+# When the MPI environment changes (e.g., different module loaded), cached builds
+# must be invalidated even if the mpicc path hasn't changed.
+compute_env_fingerprint() {
+  local mpicc_path="${1:-}"
+  local fingerprint_parts=""
+
+  # 1. mpicc path
+  fingerprint_parts+="mpicc=${mpicc_path};"
+
+  # 2. mpicc -show output (captures link flags, include paths, library paths)
+  if [[ -n "${mpicc_path}" && -x "${mpicc_path}" ]]; then
+    fingerprint_parts+="mpicc_show=$("${mpicc_path}" -show 2>/dev/null || true);"
+  fi
+
+  # 3. MPI_HOME if set
+  fingerprint_parts+="MPI_HOME=${MPI_HOME:-};"
+
+  # 4. Key MPI-related env vars that affect library resolution
+  fingerprint_parts+="LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-};"
+
+  # 5. Module list (if available)
+  if command -v modulecmd >/dev/null 2>&1 || [[ -n "${LOADEDMODULES:-}" ]]; then
+    fingerprint_parts+="LOADEDMODULES=${LOADEDMODULES:-};"
+  fi
+
+  # 6. srun/slurm version if srun is the launcher
+  if check_cmd srun; then
+    fingerprint_parts+="srun_version=$(srun --version 2>/dev/null || true);"
+  fi
+
+  # Hash the fingerprint for compact storage
+  printf '%s' "${fingerprint_parts}" | sha256sum | awk '{print $1}'
+}
+
+# Check srun/slurmd version compatibility and PMI2 connectivity.
+# Slurm version mismatches between srun and slurmd cause silent PMI2 failures.
+check_slurm_pmi() {
+  local srun_bin="$1"
+  local partition="${2:-}"
+  local warned=0
+
+  if [[ ! -x "${srun_bin}" ]]; then
+    return 0
+  fi
+
+  local srun_version
+  srun_version="$("${srun_bin}" --version 2>/dev/null | awk '{print $2}')"
+  if [[ -z "${srun_version}" ]]; then
+    log "WARNING: Could not determine srun version"
+    return 0
+  fi
+  log "srun version: ${srun_version} (${srun_bin})"
+
+  # Check slurmd versions on target partition nodes
+  local partition_nodes=""
+  if [[ -n "${partition}" ]]; then
+    partition_nodes="$(scontrol show partition "${partition}" 2>/dev/null | grep -oP 'Nodes=\K\S+' || true)"
+  fi
+  if [[ -z "${partition_nodes}" ]]; then
+    # Try to get nodes from default partition or any available
+    partition_nodes="$(scontrol show partition 2>/dev/null | grep -oP 'Nodes=\K\S+' | head -1 || true)"
+  fi
+
+  if [[ -n "${partition_nodes}" ]]; then
+    # Expand node list and check versions
+    local node_versions
+    node_versions="$(scontrol show node "${partition_nodes}" 2>/dev/null | grep -oP 'Version=\K\S+' | sort -u || true)"
+    if [[ -n "${node_versions}" ]]; then
+      local srun_major srun_minor
+      srun_major="$(echo "${srun_version}" | cut -d. -f1-2)"
+      while IFS= read -r nv; do
+        local nv_major
+        nv_major="$(echo "${nv}" | cut -d. -f1-2)"
+        if [[ "${srun_major}" != "${nv_major}" ]]; then
+          log "WARNING: srun version (${srun_version}) does not match slurmd on compute nodes (${nv})"
+          log "WARNING: This version mismatch causes PMI2 communication failures!"
+          log "WARNING: The srun major.minor (${srun_major}) differs from slurmd (${nv_major})"
+
+          # Try to find a matching srun: prefer exact version, fall back to major.minor
+          local slurm_base="/usr/local/packages/slurm"
+          local exact_match="" major_match=""
+          if [[ -d "${slurm_base}" ]]; then
+            # Check exact version path first
+            if [[ -x "${slurm_base}/${nv}/bin/srun" ]]; then
+              exact_match="${slurm_base}/${nv}/bin/srun"
+            fi
+            # Scan for major.minor match as fallback
+            if [[ -z "${exact_match}" ]]; then
+              for d in "${slurm_base}"/*/bin/srun; do
+                if [[ -x "$d" ]]; then
+                  local dv
+                  dv="$("$d" --version 2>/dev/null | awk '{print $2}' || true)"
+                  if [[ "${dv}" == "${nv}" ]]; then
+                    exact_match="$d"
+                    break
+                  fi
+                  local dv_major
+                  dv_major="$(echo "${dv}" | cut -d. -f1-2)"
+                  if [[ "${dv_major}" == "${nv_major}" && -z "${major_match}" ]]; then
+                    major_match="$d"
+                  fi
+                fi
+              done
+            fi
+            local best_match="${exact_match:-${major_match}}"
+            if [[ -n "${best_match}" ]]; then
+              log "WARNING: Found compatible srun at: ${best_match}"
+              log "WARNING: Use --launcher ${best_match} to fix this"
+            fi
+          fi
+          warned=1
+        fi
+      done <<< "${node_versions}"
+    fi
+  fi
+
+  if [[ "${warned}" == "1" ]]; then
+    fail "Slurm version mismatch detected (see above). Use --launcher <path> to specify a compatible srun, or --skip-pmi-check to bypass this check."
+  fi
+
+  # Quick PMI2 connectivity test: run a trivial command through srun
+  if [[ "${E4S_CL_SKIP_PMI_CHECK}" != "1" ]]; then
+    log "Running PMI2 connectivity sanity check..."
+    local pmi_test_args=("-n" "1")
+    if [[ -n "${partition}" ]]; then
+      pmi_test_args+=("-p" "${partition}")
+    fi
+    set +e
+    local pmi_output
+    pmi_output="$("${srun_bin}" "${pmi_test_args[@]}" --mpi=pmi2 hostname 2>&1)"
+    local pmi_ret=$?
+    set -e
+    if [[ $pmi_ret -ne 0 ]]; then
+      log "WARNING: PMI2 sanity check failed (exit ${pmi_ret}):"
+      log "${pmi_output}" | tail -n 5
+      log ""
+      log "This typically indicates:"
+      log "  1. srun/slurmd version mismatch (most common)"
+      log "  2. PMI2 library incompatibility"
+      log "  3. Slurm configuration issue"
+      log ""
+      log "Try: --launcher <path-to-matching-srun> or check 'srun --version' vs 'scontrol show node <node> | grep Version'"
+      fail "PMI2 connectivity test failed. Use --skip-pmi-check to bypass."
+    else
+      log "PMI2 connectivity check passed"
+    fi
   fi
 }
 
@@ -479,6 +717,22 @@ HOST_MPI_VERSION="$("${HOST_MPIRUN}" --version 2>/dev/null | head -n 2 || true)"
 HOST_MPI_FAMILY="$(detect_mpi_family "${HOST_MPI_VERSION}")"
 log "Detected host MPI family: ${HOST_MPI_FAMILY:-unknown}"
 
+# Slurm version / PMI sanity check (when srun is the launcher)
+if [[ "${LAUNCHER_BIN##*/}" == "srun" ]]; then
+  # Extract partition from launcher args if present (look for -p or --partition)
+  LAUNCHER_PARTITION=""
+  for ((i=0; i<${#LAUNCHER_ARGS[@]}; i++)); do
+    if [[ "${LAUNCHER_ARGS[$i]}" == "-p" || "${LAUNCHER_ARGS[$i]}" == "--partition" ]]; then
+      LAUNCHER_PARTITION="${LAUNCHER_ARGS[$((i+1))]:-}"
+      break
+    fi
+  done
+  check_slurm_pmi "${LAUNCHER_BIN}" "${LAUNCHER_PARTITION}"
+fi
+
+# Compute environment fingerprint for build cache validation
+ENV_FINGERPRINT="$(compute_env_fingerprint "${HOST_MPICC}")"
+log "Environment fingerprint: ${ENV_FINGERPRINT:0:12}..."
 
 log "Step 1: Setting up e4s-cl. Using a local virtual environment and editable install to ensure the latest code is used."
 
@@ -618,10 +872,16 @@ if [[ ! -d "${OSU_HOST_PREFIX}" || ! -f "${OSU_HOST_META}" ]]; then
   REBUILD_HOST_OSU="1"
 elif ! grep -Fq "mpicc=${HOST_MPICC}" "${OSU_HOST_META}"; then
   REBUILD_HOST_OSU="1"
+  log "Build cache invalidated: mpicc path changed"
 elif ! grep -Fq "mpicc_version=${HOST_MPICC_VERSION}" "${OSU_HOST_META}"; then
   REBUILD_HOST_OSU="1"
+  log "Build cache invalidated: mpicc version changed"
 elif ! grep -Fq "osu_url=${E4S_CL_OSU_URL}" "${OSU_HOST_META}"; then
   REBUILD_HOST_OSU="1"
+  log "Build cache invalidated: OSU URL changed"
+elif ! grep -Fq "env_fingerprint=${ENV_FINGERPRINT}" "${OSU_HOST_META}"; then
+  REBUILD_HOST_OSU="1"
+  log "Build cache invalidated: MPI environment changed (modules, LD_LIBRARY_PATH, MPI_HOME, etc.)"
 fi
 
 if [[ "${REBUILD_HOST_OSU}" == "1" ]]; then
@@ -649,7 +909,7 @@ if [[ "${REBUILD_HOST_OSU}" == "1" ]]; then
     
     run_silent build_cmd
   )
-  printf "mpicc=%s\nmpicc_version=%s\nosu_url=%s\n" "${HOST_MPICC}" "${HOST_MPICC_VERSION}" "${E4S_CL_OSU_URL}" > "${OSU_HOST_META}"
+  printf "mpicc=%s\nmpicc_version=%s\nosu_url=%s\nenv_fingerprint=%s\n" "${HOST_MPICC}" "${HOST_MPICC_VERSION}" "${E4S_CL_OSU_URL}" "${ENV_FINGERPRINT}" > "${OSU_HOST_META}"
 else
   log "Reusing host OSU benchmarks: ${OSU_HOST_PREFIX}"
 fi
@@ -784,6 +1044,20 @@ profile_has_bindings() {
   fi
   return 1
 }
+
+# Propagate the demo timeout to e4s-cl's internal detect timeout so that
+# srun-based launches (which include job-scheduling overhead) don't hit the
+# default 120 s ceiling before the outer timeout fires.
+# E4S_CL_TIMEOUT_DURATION may have a suffix (s/m/h); convert to seconds.
+_detect_timeout="${E4S_CL_TIMEOUT_DURATION}"
+if [[ "${_detect_timeout}" =~ ^([0-9]+)[sS]?$ ]]; then
+  _detect_timeout="${BASH_REMATCH[1]}"
+elif [[ "${_detect_timeout}" =~ ^([0-9]+)[mM]$ ]]; then
+  _detect_timeout=$(( BASH_REMATCH[1] * 60 ))
+elif [[ "${_detect_timeout}" =~ ^([0-9]+)[hH]$ ]]; then
+  _detect_timeout=$(( BASH_REMATCH[1] * 3600 ))
+fi
+export __E4S_CL_DETECT_TIMEOUT="${_detect_timeout}"
 
 if [[ "${E4S_CL_SKIP_PROFILE_DETECT}" == "1" ]]; then
   if profile_has_bindings; then

--- a/tests/test_filter_mpi.py
+++ b/tests/test_filter_mpi.py
@@ -1,0 +1,223 @@
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from e4s_cl.cli.commands.profile.detect import _filter_mpi_artifacts
+
+class FilterMPITest(unittest.TestCase):
+    def setUp(self):
+        self.tmp_dir_obj = TemporaryDirectory()
+        self.tmp_dir = Path(self.tmp_dir_obj.name)
+        
+        # Create 'system' MPI
+        self.sys_mpi = self.tmp_dir / "usr/lib/mpich/lib/libmpi.so"
+        self.sys_mpi.parent.mkdir(parents=True)
+        self.sys_mpi.touch()
+
+        # Create 'system' launcher
+        self.sys_launcher = self.tmp_dir / "usr/bin/mpirun"
+        self.sys_launcher.parent.mkdir(parents=True)
+        self.sys_launcher.touch()
+        self.sys_launcher.chmod(0o755)
+
+        # Create 'conflicting' Intel MPI
+        self.intel_mpi = self.tmp_dir / "opt/intel/oneapi/lib/libmpi.so"
+        self.intel_mpi.parent.mkdir(parents=True)
+        self.intel_mpi.touch()
+
+        # Create unrelated artifact (depends on Intel MPI)
+        self.intel_dep = self.tmp_dir / "opt/intel/oneapi/lib/libfabric.so"
+        self.intel_dep.touch()
+
+    def tearDown(self):
+        self.tmp_dir_obj.cleanup()
+
+    def test_filter_pollution(self):
+        libs = [self.sys_mpi, self.intel_mpi, self.intel_dep]
+        files = []
+        
+        filtered_libs, filtered_files = _filter_mpi_artifacts(libs, files, self.sys_launcher)
+        
+        # We expect sys_mpi to be present
+        self.assertIn(str(self.sys_mpi), filtered_libs)
+        
+        # We expect intel_mpi to be removed
+        self.assertNotIn(str(self.intel_mpi), filtered_libs)
+        
+        # We expect intel_dep to be KEPT now, because we whitelist non-core libs
+        self.assertIn(str(self.intel_dep), filtered_libs)
+
+    def test_filter_system_usr(self):
+        # Scenario: Launcher in /usr/bin, lib in /usr/lib
+        # This checks the "system" heuristic
+        
+        libs = [self.sys_mpi]
+        files = []
+        filtered_libs, _ = _filter_mpi_artifacts(libs, files, self.sys_launcher)
+        self.assertIn(str(self.sys_mpi), filtered_libs)
+
+    def test_filter_divergent_paths_kept(self):
+        """
+        Divergent paths (where launcher and lib don't share prefix) are kept 
+        if no other library matches the launcher. Fail-open behavior.
+        """
+        divergent_dir = self.tmp_dir / "opt/divergent"
+        divergent_dir.mkdir(parents=True)
+        
+        launcher = divergent_dir / "bin/mpirun"
+        launcher.parent.mkdir(parents=True)
+        launcher.touch()
+        
+        lib = divergent_dir / "custom/lib/libmpi.so"
+        lib.parent.mkdir(parents=True)
+        lib.touch()
+        
+        libs = [lib]
+        files = []
+        filtered_libs, _ = _filter_mpi_artifacts(libs, files, launcher)
+        
+        self.assertIn(str(lib), filtered_libs)
+
+    def test_example_a_openmpi_external_deps(self):
+        """
+        Example A: Open MPI built with external PMIx / UCX / HWLOC
+        Should keep all libraries because they are required deps, even if different prefixes.
+        """
+        launcher = Path('/opt/mpi/openmpi/4.1.6/bin/mpirun')
+        libs = [
+            Path('/opt/mpi/openmpi/4.1.6/lib/libmpi.so'),
+            Path('/opt/pmix/4.2.6/lib/libpmix.so'),
+            Path('/opt/ucx/1.15.0/lib/libucp.so'),
+            Path('/usr/lib64/libhwloc.so')
+        ]
+        files = []
+        
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files, launcher)
+        
+        self.assertEqual(len(kept_libs), 4)
+        self.assertIn('/opt/mpi/openmpi/4.1.6/lib/libmpi.so', kept_libs)
+
+    def test_example_c_vendor_wrapper(self):
+        """
+        Example C: Vendor launcher + Spack-provided MPI
+        Launcher in /usr/bin, MPI in /opt/spack via LD_LIBRARY_PATH.
+        Should keep everything.
+        """
+        launcher = Path('/usr/bin/mpirun')
+        libs = [
+            Path('/opt/spack/openmpi/lib/libmpi.so'),
+            Path('/opt/spack/pmix/lib/libpmix.so')
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files, launcher)
+
+        self.assertEqual(len(kept_libs), 2)
+
+    def test_example_e_worst_case(self):
+        """
+        Example E: Mixed environment with /usr/bin launcher
+        """
+        launcher = Path('/usr/bin/mpirun')
+        libs = [
+            Path('/opt/spack/openmpi/lib/libmpi.so'),
+            Path('/opt/spack/pmix/lib/libpmix.so'),
+            Path('/usr/lib64/libhwloc.so'),
+            Path('/opt/intel/oneapi/lib/libfabric.so')
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files, launcher)
+
+        self.assertEqual(len(kept_libs), 4)
+
+    def test_multiple_mpi_core_libs(self):
+        """
+        Scenario where multiple MPI core libs exist.
+        Should pick authoritative one (closest to launcher) and discard other CORE libs.
+        But keep non-core libs even if under discarded prefix.
+        """
+        launcher = Path('/opt/ompi/bin/mpirun')
+        libs = [
+            Path('/opt/ompi/lib/libmpi.so'),        # Authoritative
+            Path('/opt/mpich/lib/libmpich.so'),     # Conflicting MPI
+            Path('/opt/mpich/lib/libfabric.so'),    # Useful dep in discarded prefix
+            Path('/opt/other/lib/libfoo.so')        # Neutral
+        ]
+        
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files=[], launcher=launcher)
+        
+        self.assertIn('/opt/ompi/lib/libmpi.so', kept_libs)
+        self.assertNotIn('/opt/mpich/lib/libmpich.so', kept_libs)
+        self.assertIn('/opt/mpich/lib/libfabric.so', kept_libs)
+        self.assertIn('/opt/other/lib/libfoo.so', kept_libs)
+
+    def test_mpi_filter_off(self):
+        """
+        Test disabling the filter.
+        """
+        launcher = Path('/opt/ompi/bin/mpirun')
+        libs = [
+            Path('/opt/ompi/lib/libmpi.so'),
+            Path('/opt/mpich/lib/libmpich.so'),
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files, launcher, mpi_filter='off')
+        
+        self.assertEqual(len(kept_libs), 2)
+
+    def test_mpi_filter_manual(self):
+        """
+        Test manual filter (disables auto filter, but respects exclusions if provided - tested separately).
+        Solely manual should return everything if no exclusions provided.
+        """
+        launcher = Path('/opt/ompi/bin/mpirun')
+        libs = [
+            Path('/opt/ompi/lib/libmpi.so'),
+            Path('/opt/mpich/lib/libmpich.so'),
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(libs, files, launcher, mpi_filter='manual')
+
+        self.assertEqual(len(kept_libs), 2)
+
+    def test_exclude_lib_name(self):
+        """
+        Test manual exclusion by name.
+        """
+        launcher = Path('/opt/ompi/bin/mpirun')
+        libs = [
+            Path('/opt/ompi/lib/libmpi.so'),
+            Path('/opt/mpich/lib/libmpich.so'),
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(
+            libs, files, launcher, 
+            mpi_filter='auto', 
+            exclude_names=['libmpich.so']
+        )
+        
+        self.assertIn('/opt/ompi/lib/libmpi.so', kept_libs)
+        self.assertNotIn('/opt/mpich/lib/libmpich.so', kept_libs)
+
+    def test_exclude_lib_prefix(self):
+        """
+        Test manual exclusion by prefix.
+        """
+        launcher = Path('/opt/ompi/bin/mpirun')
+        libs = [
+            Path('/opt/ompi/lib/libmpi.so'),
+            Path('/opt/bad/lib/libbad.so'),
+        ]
+        files = []
+
+        kept_libs, kept_files = _filter_mpi_artifacts(
+            libs, files, launcher, 
+            mpi_filter='auto', 
+            exclude_prefixes=['/opt/bad']
+        )
+        
+        self.assertIn('/opt/ompi/lib/libmpi.so', kept_libs)
+        self.assertNotIn('/opt/bad/lib/libbad.so', kept_libs)


### PR DESCRIPTION
This started as a run at a clean-start demo runner script plus file mapping support, but now includes 5 commits addressing issues I ran into while testing the demo. I need to test these changes on additional systems before they can be merged.

1. Reduce MPI environment confusion. Wi4MPI Fixes (2635a96)
Core infrastructure improvements addressing environment confusion

Problem: Artifacts from conflicting MPI stacks (e.g., Intel oneAPI libraries when using MPICH) are inadvertently captured during profile detection, requiring manual pruning or root-bind workarounds.

Changes:

MPI Artifact Filtering (detect.py)

Implemented _filter_mpi_artifacts() to discard shared objects not matching the MPI launcher's installation prefix
Heuristic: retains libraries sharing the launcher's prefix or system paths (usr, /)
Fail-open approach: conservatively retains all libraries if no match found (supports divergent installs)
New --mpi-filter argument allows activation/deactivation or manual library exclusion
Added comprehensive filtering tests (test_filter_mpi.py) with 223 lines of test coverage
Wi4MPI Robustness (__execute.py, __init__.py)

Added _alias_wi4mpi_fake_libs_for_guest() to create SONAME aliases (e.g., libmpich.so → libmpi.so) for Wi4MPI's fake libraries
Improved robustness of wi4mpi_root detection
Timeout Support (util.py)

Added timeout parameter to run_e4scl_subprocess() to prevent hangs during detect operations
Template Improvements (template.py)

Support for injecting extra environment variables into container entrypoint (used for Wi4MPI configuration)
Container Execution (launch.py, trace.py)

Explicitly filter root (/) directory from file bindings to prevent permission errors in Apptainer/Singularity
Updated opened_files() to correctly handle multi-process traces (e.g., MPI), preventing premature exit or hangs
Environment Variables (__init__.py)

Improved E4S_CL_SCRIPT resolution
Added E4S_CL_CONTAINER_DIR environment variable override for internal container directory
Impact: Eliminates manual profile pruning workarounds; vastly reduces environment confusion in multi-MPI setups.

2. Support file aliasing with host:container syntax in profiles (0188982)
Adds file path mapping capabilities

Problem: Users cannot map host files to different container paths.

Changes:

File Aliasing Parser (__execute.py)

Extended file binding logic to parse host:container syntax
Splits paths on : to detect source/destination pairs
Updated Container.bind_file() calls to use dest argument for aliased paths
Improved Validation

Added access checks for both source and destination paths
Falls back gracefully with error logging if paths not found
Documentation Updates

Updated CLI help for profile edit and execute commands to document host:container syntax
Added regression test test_execute_alias to ensure bindings are correctly applied
Example Usage: --files /host/lib/libfoo.so:/container/lib/libbar.so

3. Added step by step demo runner script (ed0afec)
Comprehensive validation and demonstration tool

Changes:

New Script (demo.sh) — 717 lines
High-level e4s-cl validation script starting from clean local build
Uses Apptainer + MPI-enabled container image
Primary focus: run container-built MPI app using host MPI
Captures host baseline, e4s-cl launch, and optional in-container baseline
Compares performance (host vs e4s-cl vs container-only)
Includes automatic environment detection and setup
Usage:


./scripts/demo.sh [--container-cmd apptainer|podman|...] [--container-image <image>] [--mpi-impl mpich|openmpi] [--np <count>]


4. Fix Wi4MPI target library binding in container (551b07f)
Critical fix for Wi4MPI library preloading

Problem: Environment variables WI4MPI_RUN_MPI_C_LIB and WI4MPI_RUN_MPI_F_LIB were updated to point to container paths without ensuring the underlying host libraries were actually bound, causing loader errors ("file too short").

Changes:

Library Import (__execute.py)
Explicitly call import_library() for WI4MPI_RUN_MPI_C_LIB before updating the environment variable
Explicitly call import_library() for WI4MPI_RUN_MPI_F_LIB before updating
Ensures host libraries are bound to container before Wi4MPI attempts preloading
Impact: Resolves Wi4MPI preload failures; enables reliable MPI API translation.

5. Detect and warn about OpenMPI CMA fallback (222348b)
Potential performance issue advisory